### PR TITLE
chore: refresh our_take editorial copy — 2026-09-01

### DIFF
--- a/data/cards/aaa-daily-advantage-visa-signature.yaml
+++ b/data/cards/aaa-daily-advantage-visa-signature.yaml
@@ -59,17 +59,15 @@ apr:
     min: 17.49
     max: 31.49
 our_take: >
-  The Daily Advantage earns 5% back at grocery stores and 3% on gas and EV
-  charging, wholesale clubs, streaming, and pharmacy purchases, all with no
-  annual fee and no foreign transaction fee. The catch is the cap: groceries,
-  wholesale clubs, and gas and EV charging share a single $500 per year cash
-  back limit, and everything past it drops to 1%, which is also the rate on
-  all other spending. That works out to roughly $10,000 of grocery spending
-  before the 5% runs out, so treat this as a card for a household's core bills
-  rather than a catch-all. The $100 bonus after $1,000 in the first three
-  months is modest but easy to clear. If you already deal with AAA, the 3%
-  back on memberships and AAA Travel bookings and the 5% redemption bonus
-  through AAA Northeast advisors are small extras on top.
+  The draw here is 5% back on groceries with no annual fee, a higher grocery
+  rate than most no-fee cash back cards pay. The catch is the cap: the 5%
+  grocery rate and the 3% rates on gas, EV charging, and wholesale clubs all
+  share a single $500 per year cash back limit, after which they drop to 1%.
+  That ceiling arrives at roughly $10,000 of grocery spend, so this fits a
+  normal household budget rather than a large one. Streaming and drugstore
+  purchases earn 3% without sharing that cap, and there are no foreign
+  transaction fees. The $100 bonus after $1,000 in three months is modest, and
+  with a regular APR of 17.49% to 31.49% this is strictly a pay-in-full card.
 benefits:
   - name: "AAA Redemption Bonus"
     value: 0

--- a/data/cards/aaa-travel-advantage-visa-signature.yaml
+++ b/data/cards/aaa-travel-advantage-visa-signature.yaml
@@ -49,16 +49,16 @@ apr:
     min: 17.49
     max: 31.49
 our_take: >
-  The Travel Advantage leads with 5% back on gas and EV charging plus 3% on
-  groceries, dining, and travel, with no annual fee and no foreign transaction
-  fee. Read the fine print on that headline rate: the 5% is limited to $350 in
-  cash back a year, roughly $7,000 of fuel spending, after which it falls to
-  1%. Everything outside the bonus categories also earns just 1%, so this is a
-  supplementary card rather than the one you reach for by default. The $100
-  bonus after $1,000 in three months is small, though the spending bar is low
-  enough that most people will clear it without trying. With a regular APR of
-  17.49% to 31.49%, it only makes sense as a rewards card if you pay in full
-  each month.
+  This is the fuel-heavy half of AAA's no-fee pair: 5% back at gas stations
+  and EV charging, plus 3% on groceries, dining, and travel, including AAA
+  purchases. The 5% rate is capped at $350 of cash back per year, about $7,000
+  of fuel spend, and falls to 1% after that, so the headline number suits a
+  commuter more than a heavy driver. The 3% categories carry no stated cap,
+  which makes the card more flexible than the top rate alone suggests, and
+  there are no foreign transaction fees when you use it abroad. The $100 bonus
+  after $1,000 in three months is small but easy to clear. Just note the 5%
+  redemption bonus only applies when you cash out through AAA Northeast, and
+  the 17.49% to 31.49% APR punishes any balance you carry.
 benefits:
   - name: "AAA Redemption Bonus"
     value: 0

--- a/data/cards/aer-lingus-visa-signature-card.yaml
+++ b/data/cards/aer-lingus-visa-signature-card.yaml
@@ -76,15 +76,14 @@ benefits:
     enrollment_required: false
 apply_link: https://creditcards.chase.com/travel-credit-cards/aer-lingus
 our_take: >
-  The 75,000 mile welcome bonus after $5,000 in three months is the main
-  reason to open this card, and it is a big haul against a $95 annual fee.
-  Ongoing earning is narrow: 3x applies only to Aer Lingus, British Airways,
-  and Iberia flights, 2x to hotels booked directly, and everything else earns
-  1x, so there is little reason to route daily spending here. The companion
-  ticket sounds appealing until you see the requirement, $30,000 of spend in a
-  calendar year on a card that pays 1x on most purchases. The perks that cost
-  nothing extra are the more practical ones: no foreign transaction fees,
-  priority boarding on Aer Lingus flights between the US and Ireland, 10% off
-  Aer Lingus flights from the US to Europe booked through the cardmember site,
-  and baggage delay and lost luggage coverage. Worth holding if you fly Aer
-  Lingus regularly, otherwise take the bonus and reassess at renewal.
+  The reason to take this card is the 75,000-mile welcome bonus after $5,000
+  in three months, a large haul for a $95 annual fee. Beyond that the earn is
+  narrow: 3x on Aer Lingus, British Airways, and Iberia flights, 2x on hotels
+  booked directly, and 1x on everything else, so it is not built for daily
+  spend. The ongoing perks are tied to the airline itself, with priority
+  boarding on flights between the US and Ireland and 10% off Aer Lingus
+  flights to Europe booked through the cardmember site. A complimentary
+  economy companion ticket is on offer, but only after $30,000 of spend in a
+  calendar year, which is a high bar for most people. If you fly to Ireland
+  regularly, the bonus and the flight discount can carry the fee; otherwise
+  there is little reason to keep it past the first year.

--- a/data/cards/air-france-klm-visa-signature.yaml
+++ b/data/cards/air-france-klm-visa-signature.yaml
@@ -65,14 +65,15 @@ benefits:
     category: "other"
 apply_link: https://www.bankofamerica.com/credit-cards/products/air-france-credit-card/
 our_take: >
-  The number that stands out here is 1.5x on everything else, which is
-  unusually strong for an airline card and means your non category spending is
-  not wasted. On top of that sit 3x on Air France, KLM, and other SkyTeam
-  airline purchases and 3x on dining, for an $89 annual fee with no foreign
-  transaction fees. The 50,000 mile bonus after only $2,000 in three months is
-  one of the lower spending bars around, and it comes with 100 XP toward
-  Flying Blue elite status. Recurring value is thinner: 5,000 anniversary
-  miles after just $50 of spend, and 20 XP a year that only scales to 100 XP
-  total at $15,000 of annual spend and 160 XP at $25,000. Keep it if Flying
-  Blue awards are how you actually fly, since your miles stay active as long
-  as the account is open.
+  The standout here is the 1.5x base rate on all other purchases, which is
+  unusually generous for an airline card and means non-bonus spend still
+  builds Flying Blue miles at a decent clip. On top of that you get 3x on Air
+  France, KLM, and other SkyTeam airline purchases and 3x at restaurants, with
+  50,000 miles plus 100 elite qualifying XP after $2,000 in three months. The
+  $89 annual fee is partly answered by 5,000 anniversary miles each year,
+  which need only $50 of spend, and by 20 XP toward Flying Blue status. That
+  status angle scales with spend, reaching 100 XP at $15,000 and 160 XP at
+  $25,000 a year, so it rewards a committed Flying Blue flyer far more than a
+  casual one. Miles stay active while the account is open and there are no
+  foreign transaction fees, both of which matter on a card built for European
+  travel.

--- a/data/cards/alliant-cashback-visa-signature.yaml
+++ b/data/cards/alliant-cashback-visa-signature.yaml
@@ -18,12 +18,11 @@ rewards:
     note: "Flat rate on all purchases since November 1, 2025; the previous 2.5% Tier One structure (with Alliant High-Rate Checking) has been discontinued"
 benefits: []
 our_take: >
-  Alliant has stopped accepting applications, so this is now a question of
-  whether to keep a card you already hold rather than whether to get one. The
-  earn rate is a flat 1.5% on all purchases with no annual fee and no foreign
-  transaction fee, which is plain but usable. The important context is the
-  downgrade: the old 2.5% Tier One structure tied to Alliant High-Rate
-  Checking was discontinued on November 1, 2025, and 1.5% is what is left.
-  There is no signup bonus and no benefits package attached, so the rate is
-  the entire proposition. At 1.5% flat it sits behind the stronger flat-rate
-  cards, which makes it a reasonable backup and a poor everyday default.
+  Alliant has closed this card to new applications, so this is a note for
+  existing holders rather than a recommendation. Since November 1, 2025 it
+  pays a flat 1.5% on everything, replacing the old 2.5% Tier One structure
+  that required an Alliant High-Rate Checking account. At 1.5% with no annual
+  fee and no foreign transaction fees it is still a serviceable catch-all, but
+  the rate no longer stands out against ordinary flat-rate cards. There are no
+  benefits attached to fall back on either. Keep it as a backup if you already
+  have it, but the reason people sought it out is gone.

--- a/data/cards/amazon-business-prime-american-express-card.yaml
+++ b/data/cards/amazon-business-prime-american-express-card.yaml
@@ -41,13 +41,14 @@ tags:
 apply_link: https://www.americanexpress.com/us/credit-cards/business/business-credit-cards/amazon-business-prime-card/
 network: "amex"
 our_take: >
-  American Express is no longer accepting applications for this one, so it
-  matters mainly to businesses that already hold it. For those that do, the
-  core rate is genuinely strong: 5% back on US purchases at Amazon.com, Amazon
-  Business, AWS, and Whole Foods Market, with a high $120,000 annual cap
-  before it drops to 1%. Everything else is ordinary, 2% at US restaurants and
-  gas stations and 1% on all other spending, so the card earns its keep only
-  if your Amazon and AWS invoices are large. There is no annual fee, and the
-  $125 welcome bonus carried no spending requirement at all. If your business
-  buys its supplies and cloud through Amazon, keep it open and leave the rest
-  of your spending on a broader card.
+  The pitch is simple: 5% back on U.S. purchases at Amazon.com, Amazon
+  Business, AWS, and Whole Foods Market, on up to $120,000 of spend a year,
+  with no annual fee. That cap is high enough that most small businesses will
+  never touch it, and including AWS makes the card more useful than a typical
+  retail co-brand. Outside that the earn thins out quickly, with 2% at U.S.
+  restaurants and gas stations and 1% on everything else, so it works as a
+  supplement rather than a primary business card. The $125 welcome bonus
+  carries no spend requirement, which is a rare and genuinely easy offer. Amex
+  is no longer accepting new applications, so this is guidance for current
+  cardholders, and with a regular APR of 18.24% to 26.24% it is a card to
+  clear every month.

--- a/data/cards/amazon-prime-rewards-visa-signature-card.yaml
+++ b/data/cards/amazon-prime-rewards-visa-signature-card.yaml
@@ -51,18 +51,17 @@ page_check_url: https://creditcards.chase.com/cash-back-credit-cards/amazon-prim
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  For Prime members this is one of the simplest high-rate shopping cards: 5%
-  back at Amazon, Whole Foods, and Shopbop plus 5% on Chase Travel bookings,
-  with no annual fee and no foreign transaction fee. Without an eligible Prime
-  membership those rates drop to 3%, so the card's headline value is tied to a
-  subscription you pay for separately. Away from Amazon the earn is average,
-  2% on dining, gas, and transit and 1% on everything else, which is why it
-  lands at #10 on our Best Cash Back list rather than near the top. Chase
-  briefly raised the welcome offer to $200 in June before pulling it back to a
-  $150 Amazon gift card in July, so it may be worth waiting for the next bump
-  if you are not in a hurry. The purchase and travel protections, including
-  baggage delay and lost luggage coverage, are more than most shopping cards
-  bother with.
+  With an eligible Prime membership this card returns 5% at Amazon, Whole
+  Foods, and Shopbop plus 5% on Chase Travel bookings, which is what puts it
+  at number 10 on our Best Cash Back list. Without Prime those rates fall to
+  3%, so the real price of the card is the membership, not an annual fee,
+  since there is none. The rest of the earn is reasonable rather than
+  exciting: 2% on dining, gas, and transit, and 1% everywhere else. The
+  welcome offer is a gift card loaded on approval with no spend requirement,
+  and it moves around, rising to $200 in June before dropping back to $150 in
+  July, so check the current number before you apply. No foreign transaction
+  fees and Chase's baggage, travel accident, and purchase protections round it
+  out.
 benefits:
   - name: "Purchase Protection"
     value: 0

--- a/data/cards/amazon-store-card.yaml
+++ b/data/cards/amazon-store-card.yaml
@@ -37,15 +37,14 @@ apr:
 apply_link: https://www.amazon.com/Synchrony-Bank-Amazon-com-Store-Card/dp/B008A0GNA8
 foreign_transaction_fee: false
 our_take: >
-  This is a closed-loop store card: it works at Amazon.com, select physical
-  Amazon stores, Whole Foods with an in-store code, and merchants that accept
-  Amazon Pay, and nowhere else. The draw is 5% back on Amazon and Whole Foods
-  purchases for Prime cardmembers, with no annual fee, but there is no 5% at
-  all without an eligible Prime membership. The welcome gift card has been cut
-  twice this year, from $60 to $10 in June and to zero in July, so there is no
-  meaningful signup incentive left. What remains distinctive is the 0% equal
-  monthly payment financing: six months on Amazon purchases from $50 to
-  $599.99, twelve months at $600 and up, and 24 months on select purchases.
-  Use it to spread out a large Amazon order and clear it before the plan ends,
-  because the 29.49% regular APR wipes out the rewards fast if a balance
-  lingers.
+  This is only worth considering if you spend heavily at Amazon and already
+  pay for Prime, because the 5% back on Amazon and Whole Foods purchases
+  disappears without an eligible membership. It is a closed-loop card, usable
+  only at Amazon, select Amazon stores, Whole Foods with an in-store code, and
+  merchants that accept Amazon Pay, so it can never be a primary card. The
+  financing is the other draw: 0% equal monthly payments over 6 months on
+  Amazon purchases from $50 to $599.99, 12 months on purchases of $600 or
+  more, and 24 months on select items. Weigh that against a fixed 29.49% APR,
+  which is what applies to anything outside a promotional plan. The signup
+  gift card has also been shrinking, from $60 to $10 in June and to nothing in
+  July, so there is no upfront incentive left to open it.

--- a/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
+++ b/data/cards/american-airlines-aadvantage-mileu-mastercard.yaml
@@ -32,16 +32,16 @@ apply_link: https://www.citi.com/credit-cards/aadvantage-mile-up-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The MileUp is the no-fee entry point to AAdvantage miles, earning 2x at
-  grocery stores, 2x on eligible American Airlines purchases, and 1x on
-  everything else, with 15,000 miles after just $500 of spend in three months.
-  That low bar makes it cheap to add, and it carries our Best No-Fee badge on
-  the Best Airline Credit Cards list at #18. The perks match the price: the
-  benefits list stops at 25% off eligible inflight food and beverage purchases
-  on American flights. It also charges foreign transaction fees, an awkward
-  gap on an airline card that rules it out for spending abroad. Think of it as
-  a way to keep an AAdvantage balance topped up with grocery spending, not as
-  a primary travel card.
+  For a card with no annual fee, 2x AAdvantage miles at grocery stores is the
+  real reason to carry it, and it is why the card takes the Best No-Fee badge
+  at number 18 on our Best Airline list. You also earn 2x on eligible American
+  Airlines purchases and 1x elsewhere, with a 15,000-mile bonus after just
+  $500 of spend in three months, one of the easier bonuses on the market to
+  clear. The tradeoff is that this is a stripped-down airline card: the only
+  ongoing perk listed is a 25% discount on inflight food and beverages. It
+  also charges foreign transaction fees, an odd flaw on an airline product, so
+  leave it home on international trips. Treat it as a way to top up an
+  AAdvantage balance with grocery spend, not as a travel card.
 benefits:
   - name: "Inflight Food & Beverage Discount"
     value: 25

--- a/data/cards/american-express-business-gold-card.yaml
+++ b/data/cards/american-express-business-gold-card.yaml
@@ -90,19 +90,19 @@ apply_link: https://www.americanexpress.com/us/credit-cards/business/business-cr
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  Business Gold's pitch is that you do not have to plan around categories: 4x
-  points land automatically on your top two eligible spending categories each
-  billing cycle, chosen from six that include US restaurants, gas stations,
-  transit, wireless service, advertising, and electronics and software, up to
-  $150,000 of combined annual spend before the rate falls to 1x. Amex raised
-  the welcome offer in May from 100,000 to as much as 200,000 points after
-  $15,000 in three months, though it is advertised as an up-to figure, so your
-  actual offer may come in lower. The $375 annual fee is meant to be absorbed
-  by credits: $20 a month across FedEx, Grubhub, and office supply stores,
-  $300 a year toward ChatGPT, up to $12.95 a month for Walmart+, $150 for
-  Squarespace, and $100 toward on-property charges at Hotel Collection stays.
-  Nearly all of those require enrollment and arrive in monthly slices, so the
-  fee only pencils out if your business genuinely spends at those merchants
-  month after month. Flights and prepaid hotels through AmexTravel.com earn 3x
-  and everything outside the bonus categories earns 1x, which makes this a
-  card for concentrated category spending rather than broad volume.
+  The Business Gold does the category work for you, paying 4x on your top two
+  spending categories each billing cycle out of six eligible ones, including
+  U.S. advertising, restaurants, gas, transit, wireless service, and
+  electronics and software providers, on up to $150,000 of combined spend a
+  year. The welcome offer doubled in May 2026, from 100,000 to as much as
+  200,000 Membership Rewards points after $15,000 in three months, though Amex
+  frames it as an offer of up to that amount, so what you are actually
+  approved for may be smaller. The $375 annual fee is steep, but the credit
+  stack is unusually deep for a business card: up to $240 a year at FedEx,
+  Grubhub, and office supply stores, $300 in ChatGPT credits, $150 with
+  Squarespace, and roughly $155 toward Walmart+. Each of those requires
+  enrollment and pays out in fixed monthly or annual slices, so the value is
+  only real if your business already buys from those vendors. Outside the top
+  two categories and 3x on AmexTravel.com flights and prepaid hotels,
+  everything earns 1x, which is the main argument for pairing it with a second
+  card.

--- a/data/cards/american-express-gold-card.yaml
+++ b/data/cards/american-express-gold-card.yaml
@@ -8,21 +8,18 @@ foreign_transaction_fee: false
 network: "amex"
 card_referral_link: "https://www.americanexpress.com/en-us/referral/personal/gold-card?ref="
 our_take: >
-  The Gold's case is its earn rate on the two categories most households spend
-  the most in: 4 points per dollar at restaurants on up to $50,000 a year and
-  4 points per dollar at U.S. supermarkets on up to $25,000, which is why it
-  sits at #1 on our list of best cards for dining and groceries. The current
-  welcome offer of 100,000 points after $8,000 in six months is among the
-  larger ones on the market. The catch is that the $325 annual fee is only
-  offset if you actually use the credits, and they are narrow and time-boxed:
-  $10 a month in Uber Cash, $10 a month split across Grubhub, The Cheesecake
-  Factory, Goldbelly, Wine.com, and Five Guys, up to $7 a month at Dunkin',
-  and $50 twice a year at Resy restaurants, most requiring enrollment and none
-  rolling over. Spend past the caps and those 4x categories drop to 1 point
-  per dollar, and everything outside them earns 1 point per dollar from the
-  start. If your dining and grocery spend is real and the monthly credit
-  routine doesn't annoy you, the math works; if not, a no-fee card will treat
-  you better.
+  The Gold earns 4x at restaurants and 4x at U.S. supermarkets, on up to
+  $50,000 and $25,000 of annual spend respectively, which is why it ranks
+  second and carries the Best Overall badge on our Best Credit Cards for
+  Dining and Groceries list. The current 100,000-point offer after $8,000 in
+  six months is also among the larger welcome bonuses going, placing sixth on
+  our signup bonus list. The $325 annual fee only works if you actually use
+  the credits, and they arrive in small monthly pieces: $10 a month in Uber
+  Cash, $10 a month at Grubhub and a few other partners, $7 a month at Dunkin,
+  and $50 twice a year through Resy. All of them require enrollment and none
+  roll over, so a skipped month is simply money lost. Travel earning is decent
+  but secondary, with 3x on airlines and 5x on hotels prepaid through Amex
+  Travel, and everything outside the bonus categories drops to 1x.
 annual_fee: 325
 benefits:
   - name: "Uber Cash"

--- a/data/cards/american-express-green-card.yaml
+++ b/data/cards/american-express-green-card.yaml
@@ -15,17 +15,17 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/green/
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  Amex stopped accepting new applications for the Green in July 2026, so this
-  is now a card to evaluate only if you already hold one. What it did well was
-  breadth: 3 points per dollar on travel, transit, and dining, with no foreign
-  transaction fees, for a $150 annual fee. The problem for existing
-  cardholders is that the fee leans almost entirely on the $219 annual CLEAR
-  Plus credit, which is only worth having if you fly often enough to use
-  CLEAR, and everything outside those three categories earns 1 point per
-  dollar. If the CLEAR credit isn't getting used, the Wells Fargo Autograph
-  matches the same 3x on travel, transit, and dining with no annual fee, and
-  the Chase Sapphire Preferred covers dining at 3x for $95. Weigh the credit
-  against the fee at renewal rather than keeping the card out of habit.
+  Amex stopped accepting new applications for the Green in July 2026, so the
+  question now is whether to keep it, not whether to get it. It earns 3x on
+  travel, transit, and dining for a $150 annual fee, and the single offsetting
+  credit is up to $219 a year for CLEAR Plus, which only pays off if you fly
+  often enough to use it. Everything outside those three categories earns 1x,
+  which is thin for a card with a fee. If CLEAR is not part of your routine,
+  the math is hard to defend: the Wells Fargo Autograph matches the 3x on
+  travel, transit, and dining with no annual fee, and the Chase Sapphire
+  Preferred offers 3x dining and transferable points for $95. Inside Amex, the
+  Gold is the natural step up if your dining and grocery spend can clear its
+  larger fee.
 annual_fee: 150
 reward_type: "points"
 rewards:

--- a/data/cards/amtrak-guest-rewards-mastercard.yaml
+++ b/data/cards/amtrak-guest-rewards-mastercard.yaml
@@ -48,15 +48,16 @@ benefits:
     frequency: "per_redemption"
     category: "travel"
 our_take: >
-  For a $0 annual fee, this card covers the basics for an occasional Amtrak
-  rider: 2 points per dollar on Amtrak travel including onboard purchases, 2
-  points per dollar on dining anywhere, and 10% back as a statement credit on
-  onboard food and beverage. Redeeming points for Amtrak travel also returns
-  5% of them, which quietly stretches every award. FNBO trimmed the welcome
-  offer from 20,000 to 15,000 points in August 2026, still earned after $1,000
-  in the first three billing cycles, with another 5,000 points for adding an
-  authorized user in the same window through September 2, 2026 when you apply
-  via amtrak.com. Note that the 2x transit rate is gated to Amtrak itself
-  rather than transit generally, so most of your spending earns 1 point per
-  dollar. It is a reasonable free keep if you ride the train a few times a
-  year, but there isn't enough here to build a wallet around.
+  If you ride Amtrak a few times a year but not enough to justify a fee, this
+  is the no-annual-fee way to keep earning: 2 points per dollar on Amtrak
+  travel including onboard purchases, 2 points on dining, and 1 point on
+  everything else. The signup bonus is 15,000 points after $1,000 in the first
+  three billing cycles, recently trimmed from 20,000, with another 5,000
+  points for adding an authorized user in the same window when you apply
+  through amtrak.com by September 2, 2026. Two small perks do real work for
+  frequent riders: 10% back as a statement credit on onboard food and
+  beverage, and 5% of your points returned when you redeem for Amtrak travel.
+  There are also no foreign transaction fees, which is unusual at this fee
+  level. The catch is that the earn rates stop at 2x and the Amtrak rate only
+  applies to Amtrak itself, so this card earns its keep on the rails and
+  nowhere else.

--- a/data/cards/amtrak-guest-rewards-preferred-mastercard.yaml
+++ b/data/cards/amtrak-guest-rewards-preferred-mastercard.yaml
@@ -75,18 +75,17 @@ benefits:
     frequency: "ongoing"
     category: "travel"
 our_take: >
-  The Preferred earns its $99 fee mostly through coupons rather than points: a
-  round-trip companion coupon, a one-class upgrade coupon, and a station
-  lounge pass, each issued at account opening and again every anniversary. On
-  spend it pays 3 points per dollar on Amtrak travel and onboard purchases, 2
-  points per dollar on dining, other travel, and non-Amtrak transit and
-  rideshare, and 1 point per dollar on everything else, plus a 20% statement
-  credit on onboard food and beverage and 5% of your points back when you
-  redeem for Amtrak travel. FNBO cut the welcome offer from 30,000 to 25,000
-  points in August 2026, earned after $1,500 in the first three billing
-  cycles, with 5,000 more for adding an authorized user through September 2,
-  2026 via amtrak.com. The 3x rate applies only to Amtrak, so if you ride once
-  or twice a year the fee is hard to clear and the no-fee version of this card
-  makes more sense. Take the Preferred if you will actually use the companion
-  coupon each year or you're chasing Amtrak elite status, which the card feeds
-  at 1,000 Tier Qualifying Points per $5,000 spent.
+  The $99 Preferred version is built for riders who use Amtrak enough to burn
+  through the annual coupons: it earns 3 points per dollar on Amtrak travel
+  including onboard purchases, 2 points on dining, other travel, and
+  non-Amtrak transit and rideshare, and 1 point elsewhere. The real value sits
+  in the anniversary benefits, a round-trip companion coupon, a one-class
+  upgrade coupon, and a station lounge pass, all issued at account opening and
+  again each year. Onboard food and beverage gets 20% back as a statement
+  credit, redemptions return 5% of your points, and every $5,000 in qualifying
+  purchases adds 1,000 Tier Qualifying Points toward Amtrak elite status. The
+  current offer is 25,000 points after $1,500 in the first three billing
+  cycles, recently cut from 30,000, plus 5,000 more for adding an authorized
+  user through September 2, 2026 via amtrak.com. Be honest with yourself about
+  the coupons: if you would not actually redeem the companion trip and the
+  upgrade, the no-fee version does the same job for $99 less.

--- a/data/cards/apple-card.yaml
+++ b/data/cards/apple-card.yaml
@@ -38,18 +38,19 @@ apply_link: https://www.apple.com/apple-card/
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  Apple Card's real appeal is friction, not rate: no annual fee, no foreign
-  transaction fee, and Daily Cash that posts immediately. Just be clear about
-  how the earning actually works. The 2% applies only when you pay through
-  Apple Pay, and the 3% is narrower still, limited to Apple purchases and a
-  specific merchant list that includes Nike, Uber, Walgreens, Booking.com,
-  ChargePoint, Duane Reade, Exxon Mobil, Hertz, and Ace Hardware. Use the
-  physical titanium card and you earn 1%, which is the card's true base rate
-  and below what plenty of no-fee cash back cards pay on everything. The
-  extras are modest: 2% in Booking.com Travel Credits on stays and car rentals
-  booked through the Apple Card portal, a six-month Uber One trial, and some
-  Hertz rental discounts. It is a fine default if nearly all your spending is
-  tap-to-pay inside the Apple ecosystem, and a weak one if it isn't.
+  The Apple Card's headline 2% Daily Cash only applies when you pay through
+  Apple Pay, and the physical titanium card drops to 1%, so treat 1% as the
+  true base rate and the 2% as an Apple Pay habit you have to maintain. The 3%
+  tier is narrower still: it covers Apple purchases and a specific merchant
+  list including Nike, Uber, Walgreens, Booking.com, ChargePoint, Duane Reade,
+  Exxon Mobil, Hertz, Ace Hardware, and only when paid with Apple Pay. There
+  is no annual fee and no foreign transaction fee, which keeps the cost of
+  carrying it at zero. A handful of partner extras round it out, including 2%
+  in Booking.com Travel Credits on eligible stays booked through the Apple
+  Card portal, a six month Uber One trial, and Hertz discounts, all requiring
+  enrollment. The regular APR runs 17.49% to 27.74%, so this is a card to use
+  for the Apple Pay flow and pay off monthly, not a rewards engine for
+  tap-resistant merchants.
 benefits:
   - name: "Booking.com Travel Credits"
     value: 2

--- a/data/cards/atlas-card.yaml
+++ b/data/cards/atlas-card.yaml
@@ -6,21 +6,21 @@ image: "atlas.png"
 apply_link: https://atlascard.com/
 foreign_transaction_fee: false
 our_take: >
-  Atlas tripled its annual fee from $1,000 to $3,000 in June 2026, and the
-  case for it now rests entirely on whether you spend the way the credits
-  assume: $3,000 toward private charter flights booked through Atlas Travel,
-  $1,000 for semi-private flights with BLADE, JSX, Aero, and Slate, $1,000
-  toward business class on bookings of $5,000 or more, $1,000 for ticketed
-  experiences, and $200 at Erewhon. The charter credit alone nominally covers
-  the fee, but only if chartering a plane was already on your calendar.
-  Earning is narrow: 5 points per dollar on bookings made through Atlas Travel
-  and 1 point per dollar on everything else, so this is not a card to route
-  general spend through. Most of the remaining value is access rather than
-  money, including an AI concierge by text, priority restaurant reservations
-  in four cities, member rates on private jets and luxury hotels, and a
-  complimentary one-year Slate Shared Membership valued at $595. If your
-  travel is commercial and getting a table isn't a problem you have, nothing
-  here justifies $3,000.
+  Atlas is a spend-heavy travel card whose math only works if you fly private
+  or semi-private: it carries a $3,000 annual fee, tripled from $1,000 in June
+  2026, and hands back $3,000 in annual private charter credit, $1,000 for
+  semi-private aviation with BLADE, JSX, Aero, and Slate, $1,000 toward
+  business class flights on bookings of $5,000 or more, and $1,000 toward
+  ticketed experiences. Earning is simple, 5 points per dollar on all Atlas
+  Travel bookings covering hotels, charter, car rentals, flights, rail,
+  cruises, and airport services, and 1 point per dollar on everything else.
+  The credits are the product, not the points, and nearly all of them are
+  locked to Atlas Travel or a named partner, so an unused charter credit is
+  $3,000 of fee you do not recover. Additional credits unlock only at extreme
+  spend levels, $1,000 after $100,000, $2,000 after $250,000, and $5,000 after
+  $1,000,000 in a year. Lifestyle extras like a $200 Erewhon credit, Sollis
+  Health access, and a complimentary one-year Slate Shared Membership are
+  pleasant but will not close the gap on their own.
 annual_fee: 3000
 category: "travel"
 reward_type: "points"

--- a/data/cards/atmos-rewards-ascent.yaml
+++ b/data/cards/atmos-rewards-ascent.yaml
@@ -70,17 +70,15 @@ benefits:
     enrollment_required: false
 apply_link: https://www.bankofamerica.com/credit-cards/products/alaska-airlines-credit-card/
 our_take: >
-  For Alaska and Hawaiian flyers, the Ascent's steadiest value is the free
-  first checked bag and preferred boarding for you and up to six guests on the
-  same reservation, which can clear the $95 annual fee on a single family
-  trip. The current offer is 70,000 points after $2,500 in three months plus a
-  $99 Companion Fare, and it has been volatile this year, reaching 80,000 in
-  late April, dropping to 50,000 in May, and settling back at 70,000 in July.
-  After year one the Companion Fare only returns at your anniversary if you
-  put $6,000 on the card during the prior year, which is the real hurdle for
-  casual flyers. The earn rates are middling away from the airline: the 3
-  points per dollar is gated to Alaska and Hawaiian purchases, 2 points per
-  dollar covers gas, EV charging, streaming, and transit, and everything else
-  is 1 point per dollar. It ranks #10 on our best travel cards list, and that
-  placement is about right: useful if you fly Alaska or Hawaiian a few times a
-  year, unremarkable if you don't.
+  The Ascent is the middle Alaska and Hawaiian card and the one most casual
+  flyers should look at first: $95 a year, 3 points per dollar on Alaska and
+  Hawaiian Airlines purchases, and 2 points on gas, EV charging, streaming,
+  and transit, with 1 point on everything else. The current offer is 70,000
+  points after $2,500 in three months plus a $99 Companion Fare, an offer that
+  fell to 50,000 in May before recovering to 70,000 in July, so timing matters
+  here. The recurring Companion Fare is the reason to keep it, though it
+  requires $6,000 in purchases in the prior anniversary year, which is a real
+  hurdle for occasional flyers. Free first checked bag and preferred boarding
+  extend to you and up to six guests on the same reservation, which can cover
+  the fee on a single family trip. It also carries no foreign transaction fees
+  and currently sits at #10 on our Best Travel Credit Cards list.

--- a/data/cards/atmos-rewards-business.yaml
+++ b/data/cards/atmos-rewards-business.yaml
@@ -14,20 +14,19 @@ check_ignore:
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The pitch here is a business card that keeps airline spending off your
-  personal credit file: activity does not report to the personal bureaus,
-  which helps if you are managing utilization or 5-24 style limits. The
-  welcome offer is 70,000 points plus a $99 Companion Fare after $4,000 in
-  purchases within 90 days, though note it briefly ran at 80,000 in May before
-  dropping back to 70,000 in July, so it is worth waiting for the higher offer
-  to return if you are not in a hurry. Ongoing earning is narrow: the 3 points
-  per dollar rate applies only to Alaska and Hawaiian Airlines purchases, with
-  2 points per dollar on gas, EV charging, transit and shipping and just 1
-  point everywhere else. Against the $95 annual fee, the recurring $99
-  Companion Fare requires $6,000 of spend each year to trigger, so the math
-  only works if you actually fly Alaska and put real volume on the card. Free
-  checked bag, priority boarding and 20% back on inflight purchases round it
-  out, and there are no foreign transaction fees.
+  This is the business version of the Alaska and Hawaiian card, same $95 fee
+  and same 3 points per dollar on Alaska and Hawaiian Airlines purchases, with
+  the category mix tuned for a company: 2 points on gas, EV charging, transit,
+  and shipping, and 1 point on everything else. The opening offer is 70,000
+  points and a $99 Companion Fare after $4,000 in the first 90 days, recently
+  trimmed from 80,000. The quiet advantage over the personal card is that
+  account activity does not report to personal credit bureaus, which keeps the
+  balance off your utilization and the account out of 5/24 style counts. The
+  recurring $99 Companion Fare needs $6,000 in annual purchases to trigger,
+  and the free checked bag here covers only the cardmember rather than a
+  party, so it is a narrower benefit than the consumer version. If your
+  business does not put meaningful spend on Alaska or Hawaiian, the 2x
+  categories alone are not enough to carry the fee.
 tags:
   - travel
   - airline

--- a/data/cards/atmos-rewards-summit.yaml
+++ b/data/cards/atmos-rewards-summit.yaml
@@ -9,21 +9,21 @@ annual_fee: 395
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Summit is built for frequent Alaska and Hawaiian flyers who will
-  actually use the companion awards, starting with a 25,000-point Global
-  Companion Award every anniversary and a second 100,000-point award if you
-  spend $60,000 in a card year. The current welcome offer is 80,000 points
-  plus a 25,000-point companion award after $4,000 in 90 days, down from
-  100,000 points as of early July, so the entry point is less generous than it
-  was. Earning is respectable at 3 points per dollar on dining and on foreign
-  purchases, but the headline 3 points on airlines is limited to Alaska and
-  Hawaiian, and everything else earns 1 point. The $395 annual fee is the real
-  hurdle: the 8 Alaska Lounge passes, $120 Global Entry or TSA PreCheck
-  credit, free checked bag and preferred boarding for you and up to 6 guests,
-  and $50 delay vouchers are useful, but they are almost all Alaska-specific.
-  It sits at #11 on our Best Travel Credit Cards list, which is about right
-  for a card this good within one airline's network and this limited outside
-  it.
+  The $395 Summit only makes sense if you will use the Global Companion Award
+  every year: you get a 25,000-point award at each anniversary, and a
+  100,000-point award if you spend $60,000 in a card year. Earning is broader
+  than the cheaper Alaska and Hawaiian cards, with 3 points per dollar on
+  Alaska and Hawaiian purchases, dining, and foreign transactions, and 1 point
+  on everything else. The travel package is genuinely deep for the price: 8
+  Alaska Lounge passes and 8 Wi-Fi passes a year, a free first checked bag and
+  priority boarding for you and up to six guests, up to $120 back on Global
+  Entry or TSA PreCheck, same-day confirmed change fees waived outside Saver
+  fares, and a $50 voucher when a flight is cancelled or delayed two hours or
+  more. The signup offer is 80,000 points plus a 25,000-point Global Companion
+  Award after $4,000 in the first 90 days, down from 100,000 points in July.
+  The tradeoff is concentration risk: outside dining and foreign spend, this
+  card is worth carrying only if Alaska and Hawaiian are your airlines. It
+  currently ranks #12 on our Best Travel Credit Cards list.
 tags:
   - travel
   - airline

--- a/data/cards/att-points-plus-from-citi.yaml
+++ b/data/cards/att-points-plus-from-citi.yaml
@@ -7,20 +7,19 @@ apply_link: https://www.citi.com/credit-cards/citi-att-pointsplus-credit-card
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The reason to carry this one is the statement credit structure rather than
-  the points: $20 back in any billing cycle where you spend at least $1,000,
-  worth up to $240 a year, plus $10 a month off an AT&T wireless line and $10
-  a month off eligible AT&T internet if you enroll in AutoPay and paperless
-  billing. Earning is decent for a no annual fee card, with 3 points per
-  dollar on gas and EV charging and 2 on groceries, though the 2 points on
-  phone applies only to AT&T products, services and bill payments, and
-  everything else earns 1 point. The welcome offer is a $200 statement credit
-  after $1,000 in purchases in the first 3 months, recently trimmed from $250.
-  The obvious catch is that most of the value assumes you are an AT&T
-  customer, and the two telecom discounts require enrollment, so a
-  non-subscriber is left with a fairly ordinary gas and grocery card. No
-  foreign transaction fees and the ability to pool points with other Citi
-  ThankYou cards are genuine extras if you already sit in that ecosystem.
+  The draw here is not the points, it is the AT&T bill credits: $10 per line
+  each month off your wireless bill and $10 a month off eligible AT&T
+  internet, both requiring AutoPay and paperless billing, worth up to $120 a
+  year each. On top of that, a $20 statement credit lands in any billing cycle
+  where you spend $1,000 or more, up to $240 a year, which is the single
+  largest line item on the card. Earning is modest by comparison, 3 points per
+  dollar on gas including EV charging, 2 on groceries, 2 on AT&T products and
+  bill payments, and 1 on everything else, with no annual fee and no foreign
+  transaction fees. The signup offer is a $200 statement credit, recently
+  trimmed from $250. If you are not an AT&T customer, almost all of the value
+  evaporates and you are left with an ordinary 3 and 2 percent earner, though
+  ThankYou point pooling with other Citi cards does give the points somewhere
+  better to go.
 annual_fee: 0
 reward_type: "points"
 tags:

--- a/data/cards/bank-of-america-cash-rewards-secured.yaml
+++ b/data/cards/bank-of-america-cash-rewards-secured.yaml
@@ -50,17 +50,16 @@ apply_link: https://www.bankofamerica.com/credit-cards/products/cash-back-secure
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  For a secured card, the earning structure is unusually good: 3% back in a
-  choice category you pick from gas, online shopping, dining, travel,
-  drugstores or home improvement, 2% at grocery stores and wholesale clubs,
-  and 1% on everything else, all with no annual fee. That flexibility is why
-  it lands at #2 on our Best Secured Credit Cards list with the Best for
-  Customization badge, since most secured cards pay a flat 1% or nothing at
-  all. The limits are real, though: the 3% and 2% rates share a combined
-  $2,500 quarterly spend cap and drop to 1% after that, so this rewards
-  moderate everyday spending rather than heavy use. The 27.49% APR is steep
-  with no intro rate to soften it, which matters because a secured card is
-  usually a rebuilding tool, and there is a foreign transaction fee, so leave
-  it home when you travel abroad. Pay in full every month, use it to establish
-  history, and treat the cash back as a bonus rather than the reason to open
-  it.
+  For a secured card, this one earns like a real rewards card: 3% back in a
+  category you choose from gas, online shopping, dining, travel, drugstores,
+  or home improvement, plus 2% at grocery stores and wholesale clubs, with no
+  annual fee. The important limit is that those bonus rates share a single
+  $2,500 quarterly cap, after which everything drops to 1%, so roughly $833 a
+  month of combined bonus spend is all you get at the higher rates. Being able
+  to move the 3% category as your spending changes is what sets it apart from
+  most deposit-backed cards, and it is why we rank it #2 on our Best Secured
+  Credit Cards list with a Best for Customization badge. Two things to watch:
+  the APR is a flat 27.49%, so this is a card to pay in full every month while
+  you build history, and it charges foreign transaction fees, which makes it a
+  poor travel companion. Used as a credit-building tool with the 3% pointed at
+  your biggest category, it does more work than a plain secured card.

--- a/data/cards/bank-of-america-customized-cash-rewards.yaml
+++ b/data/cards/bank-of-america-customized-cash-rewards.yaml
@@ -61,15 +61,15 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/cash-back-credit-card/
 our_take: >
-  The draw is control over where your 3% lands: you pick one category from
-  gas, online shopping, dining, travel, drugstores or home improvement, and
-  can shift it as your spending changes, with 2% at grocery stores and
-  wholesale clubs on top and no annual fee. Both bonus rates share a combined
-  $2,500 quarterly cap and fall to 1% beyond it, so the practical ceiling is
-  about $75 in bonus cash back per quarter before this becomes a 1% card. The
-  $200 bonus after $1,000 in the first 3 months is easy to hit, and the 15
-  months of 0% intro APR on both purchases and balance transfers gives it a
-  second use as a short term financing card. The tradeoff is a foreign
-  transaction fee, which rules it out for spending abroad, and a regular APR
-  that climbs to 27.49% once the intro window closes. Best used as a targeted
-  category card alongside a flat rate earner rather than as your only card.
+  The draw here is control: you pick one 3% category each month from gas,
+  online shopping, dining, travel, drugstores, or home improvement, and you
+  also get 2% at grocery stores and wholesale clubs, all with no annual fee.
+  The catch is the cap, and it is a shared one: the 3% choice category,
+  groceries, and wholesale clubs draw from a single $2,500 combined quarterly
+  spend limit, after which everything drops to 1%. That works out to roughly
+  $833 a month across all three buckets, so this is a supplementary card for a
+  specific spending lane rather than a card to run your whole budget through.
+  There is a $200 bonus after $1,000 in the first 3 months and 15 months of 0%
+  intro APR on both purchases and balance transfers, with the regular rate
+  landing between 17.49% and 27.49%. Skip it for spending abroad, since it
+  charges foreign transaction fees.

--- a/data/cards/bank-of-america-premium-rewards-elite.yaml
+++ b/data/cards/bank-of-america-premium-rewards-elite.yaml
@@ -64,16 +64,17 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/premium-rewards-elite-credit-card/
 our_take: >
-  The Elite justifies its $550 annual fee mostly through credits: $300 a year
-  for airline incidentals and $150 for airlines, rideshare or streaming, both
-  of which require enrollment, plus up to $120 toward Global Entry or TSA
-  PreCheck every four years. Add Priority Pass Select for you and up to three
-  authorized users and the paper value comfortably exceeds the fee, provided
-  the credits match how you actually spend. Earning is identical to the
-  cheaper Premium Rewards at 2 points per dollar on travel and dining and 1.5
-  on everything else, so you are paying the extra $455 purely for benefits,
-  not for a better return on spend. The welcome offer is 75,000 points after
-  $5,000 in the first 3 months, and there are no foreign transaction fees.
-  Worth a look if the airline incidental and lifestyle credits are money you
-  would spend anyway, and hard to justify if you would be stretching to use
-  them.
+  The case for the Elite is the credit stack: $300 a year toward airline
+  incidentals plus a $150 lifestyle credit for airlines, rideshare, or
+  streaming, which together cover $450 of the $550 annual fee if you actually
+  use both, though both require enrollment. Add Priority Pass Select for you
+  and up to three authorized users, up to $120 for Global Entry or TSA
+  PreCheck every four years, and no foreign transaction fee, and the fixed
+  value is real. Earning is simple rather than rich: 2x on travel and dining,
+  and an unusually strong 1.5x on everything else, so the card holds up as a
+  general-spend option instead of a category card. The signup bonus is 75,000
+  points after $5,000 in the first 3 months, and you can stretch points 20%
+  further on airfare paid through BofA Travel or the Concierge. The honest
+  question is whether you will use the incidental and lifestyle credits every
+  year, because without them the fee is hard to justify against the $95
+  Premium Rewards, which earns at the same rates.

--- a/data/cards/bank-of-america-premium-rewards.yaml
+++ b/data/cards/bank-of-america-premium-rewards.yaml
@@ -44,16 +44,15 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/premium-rewards-credit-card/
 our_take: >
-  The strongest argument for this card is the 1.5 points per dollar base rate,
-  which is above what most $95 travel cards pay outside their bonus
-  categories, with 2 points per dollar on travel and dining on top. The two
-  annual credits do most of the work on the fee: $100 for airline incidentals
-  like bags and seat upgrades, plus up to $100 toward Global Entry or TSA
-  PreCheck every four years, which effectively neutralizes the $95 if you fly
-  enough to use the incidental credit. The welcome offer is 60,000 points
-  after $4,000 in the first 3 months, and there are no foreign transaction
-  fees, so it travels well. The catch is that the incidental credit only
-  applies to qualifying airline fees rather than airfare itself, so if you
-  rarely check bags or buy seat upgrades, the value is thinner than the
-  headline suggests. This is a solid one card travel setup for someone who
-  wants simple earning without tracking rotating categories.
+  This is one of the more straightforward $95 travel cards: 2x on travel and
+  dining, 1.5x on everything else, and no foreign transaction fee, which means
+  you are not penalized for putting non-category spend on it. The two credits
+  do most of the work on the fee, a $100 annual airline incidental credit for
+  things like bags and seat upgrades plus up to $100 for Global Entry or TSA
+  PreCheck every four years, so a single checked-bag season roughly pays for
+  the card. The signup bonus is 60,000 points after $4,000 in the first 3
+  months. What you do not get is a lounge benefit or any intro APR, so this is
+  a card to spend on, not to carry a balance on: the regular APR runs 19.49%
+  to 27.49%. If you fly at least once or twice a year and want one card that
+  earns decently on everything, it is an easy fit; if you rarely incur airline
+  fees, the credit goes unused and the math gets thinner.

--- a/data/cards/bank-of-america-travel-rewards.yaml
+++ b/data/cards/bank-of-america-travel-rewards.yaml
@@ -30,16 +30,17 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/travel-rewards-credit-card/
 our_take: >
-  This is about as simple as travel cards get: 1.5 points per dollar on
-  everything, no annual fee and no foreign transaction fees, which is a rare
-  combination and why it holds the Best No-Fee badge at #12 on our Best Travel
-  Credit Cards list. The 25,000-point welcome offer after $1,000 in the first
-  3 months is redeemable for a $250 statement credit against travel and dining
-  purchases, an achievable target for most spending patterns. The 15 months of
-  0% intro APR on purchases and balance transfers gives it some use as a
-  financing card in year one, after which the rate runs from 17.49% to 27.49%.
-  The limitation is that there are no bonus categories at all, so a dedicated
-  travel or dining card will out earn it on those purchases, and points redeem
-  as travel statement credits rather than transferring to airline or hotel
-  partners. Keep it as a no cost card for overseas spending and a flat
-  baseline earn, not as your primary rewards engine.
+  The appeal is simplicity: a flat 1.5x points on every purchase, no annual
+  fee, and no foreign transaction fee, which earns it the Best No-Fee badge
+  and the #11 spot on our Best Travel Credit Cards list. That combination
+  makes it a reasonable passport-drawer card for trips abroad, where the
+  missing foreign transaction fee matters more than a category multiplier
+  would. New cardholders get 25,000 points after $1,000 in the first 3 months,
+  redeemable as a $250 statement credit toward travel and dining, plus 15
+  months of 0% intro APR on purchases and balance transfers before the regular
+  17.49% to 27.49% rate kicks in. The limitation is that 1.5x is the whole
+  rewards program: there are no bonus categories and no transfer partners, so
+  redemptions are statement credits against travel purchases rather than
+  anything you can leverage. Treat it as a clean, no-fee travel card for
+  people who do not want to think about categories, not as a points-maximizing
+  tool.

--- a/data/cards/bank-of-america-unlimited-cash-rewards.yaml
+++ b/data/cards/bank-of-america-unlimited-cash-rewards.yaml
@@ -32,15 +32,15 @@ apr:
     max: 27.49
 apply_link: https://www.bankofamerica.com/credit-cards/products/unlimited-cash-back-credit-card/
 our_take: >
-  The appeal is flat and predictable: 1.5% cash back on everything, no annual
-  fee, and no categories to activate or track. The welcome bonus recently
-  improved from $200 to $250 after $1,000 in purchases in the first 3 months,
-  which is a strong return for a low spend requirement and makes this a better
-  moment to apply than a few weeks ago. There are also 15 months of 0% intro
-  APR on both purchases and balance transfers, so it can pull double duty as a
-  short term financing card before the rate settles between 17.49% and 27.49%.
-  The weak spot is the foreign transaction fee, which makes it a poor choice
-  for travel abroad, and the 1.5% rate now trails the 2% flat cards available
-  elsewhere. Reasonable as a simple everyday card, especially if you already
-  bank with Bank of America, but not the strongest flat rate option on its own
-  numbers.
+  Bank of America recently raised the signup bonus from $200 to $250 after
+  $1,000 in the first 3 months, which is a solid return for a card with no
+  annual fee. Beyond the bonus, the pitch is flat 1.5% cash back on everything
+  with nothing to track, plus 15 months of 0% intro APR on both purchases and
+  balance transfers, so it can double as a short-term financing card while you
+  pay down a balance. The tradeoff is that 1.5% is the ceiling: there are no
+  bonus categories, so a 2% flat-rate card will out-earn it on every purchase
+  over the long haul. It also charges foreign transaction fees, which rules it
+  out for travel abroad. Consider it if you want the bonus and the intro
+  window and value the simplicity, but do not expect it to be your best
+  everyday earner once the 0% period ends and the regular 17.49% to 27.49% APR
+  applies.

--- a/data/cards/bankamericard.yaml
+++ b/data/cards/bankamericard.yaml
@@ -21,15 +21,15 @@ apply_link: https://www.bankofamerica.com/credit-cards/products/bankamericard-cr
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The BankAmericard is a debt paydown tool and little else: 21 months of 0%
-  intro APR on both purchases and balance transfers with no annual fee, which
-  is among the longest interest free windows available. That runway is the
-  entire reason to open it, and it earns the #2 spot with the Best No-Fee
-  badge on our Best 0% APR Credit Cards list. Be clear about what you are
-  giving up: this card earns no rewards whatsoever, so there is no cash back
-  or points to justify keeping it in rotation once the intro period ends. It
-  also charges a foreign transaction fee, so it should stay home on
-  international trips. Open it with a specific payoff plan, clear the balance
-  inside the 21 months before the rate resets to somewhere between 14.99% and
-  25.99%, and expect to move your spending elsewhere afterward.
+  The BankAmericard is built for one job, and it does that job about as well
+  as anything on the market: 21 months of 0% intro APR on both purchases and
+  balance transfers with no annual fee, which is why it sits at #2 with the
+  Best Value badge on our Best 0% APR Credit Cards list. Nearly two years of
+  interest-free runway is enough to clear most consolidation plans or spread
+  out a large purchase without paying a cent in interest. Be clear about the
+  tradeoff before you apply: this card earns no rewards at all, and there is
+  no signup bonus, so nothing gives it a reason to stay in your wallet once
+  the intro window closes. It also charges foreign transaction fees, so leave
+  it home when you travel. Open it with a payoff schedule in hand, because
+  after the intro period the regular APR runs 14.99% to 25.99%.
 

--- a/data/cards/bilt-blue.yaml
+++ b/data/cards/bilt-blue.yaml
@@ -10,20 +10,21 @@ annual_fee: 0
 reward_type: "points"
 release_date: "2025-01-15"
 our_take: >
-  Bilt Blue's whole pitch is paying rent or a mortgage by card with no
-  transaction fee, earning up to 1.25x points on that housing payment for no
-  annual fee at all. Around it you get 3x on hotels and 2x on flights booked
-  through Bilt Travel, 3x on Lyft rides once you link your Lyft account, and
-  no foreign transaction fees. The catch sits in the fine print on the
-  headline rate: the up to 1.25x only applies if you pick the housing-only
-  rewards track, and the exact multiplier is reset each billing cycle based on
-  your everyday spend relative to the housing payment. Everything else earns a
-  flat 1x, and the alternative 4% Bilt Cash track on everyday spend replaces
-  the rent points rather than adding to them, with Bilt Cash being an
-  in-ecosystem currency used mainly for point accelerators rather than true
-  cash back. The $100 in Bilt Cash at signup and the unusual 10% intro rate on
-  purchases for the first 12 billing cycles, which is a low rate and not a 0%
-  window, are small extras rather than reasons to apply.
+  Bilt Blue exists for one thing: paying rent or a mortgage by card without a
+  transaction fee, earning up to 1.25x points on housing when you choose the
+  housing rewards track, with no annual fee. That is genuinely useful, since
+  rent is usually the largest bill that earns nothing at all. Be careful with
+  the fine print, though: the exact housing multiplier is reset each billing
+  cycle based on your everyday spend relative to the housing payment, and
+  picking the alternative 4% Bilt Cash track on everyday spend drops housing
+  to 1x, so you choose one track and not both. Bilt Cash is also a separate
+  currency used mostly for point accelerators rather than actual cash back,
+  and the $100 signup bonus arrives in that form. The rest of the earn is
+  modest: 3x on hotels and 2x on flights booked through Bilt Travel, 3x on
+  Lyft rides after linking your account, and a plain 1x on everything else, so
+  this is a housing card first and an everyday card a distant second. The
+  intro APR is unusual and worth noting: 10% rather than 0% for the first 12
+  billing cycles, before a steep 26.74% to 34.74% regular rate.
 benefits:
   - name: "Rent Payment Without Fees"
     value: 0

--- a/data/cards/bilt-mastercard.yaml
+++ b/data/cards/bilt-mastercard.yaml
@@ -18,13 +18,15 @@ reward_type: "points"
 release_date: "2022-06-01"
 network: "mastercard"
 our_take: >
-  The original Bilt Mastercard is closed: it no longer accepts applications,
-  and Wells Fargo moved many holders onto other products, so there is nothing
-  here to apply for. If you still hold it, the practical question is where the
-  rent spending goes next. Bilt Blue is the direct successor and keeps the no
-  annual fee structure, with rent still earning up to 1.25x plus 3x on Bilt
-  Travel hotels and 3x on Lyft. Bilt Obsidian is the $95 step up, adding a
-  choice of 3x dining or groceries and higher travel rates on top of the same
-  rent earning. If the rent angle is no longer the point for you, the Wells
-  Fargo Autograph is the card many former holders were moved into, with 3x on
-  dining, travel, gas, transit, streaming, and phone for no annual fee.
+  The original Bilt Mastercard is no longer accepting applications, so this
+  page is now a reference point rather than a card to apply for. If the
+  fee-free rent payments were the draw, Bilt Blue is the direct successor:
+  rent still earns up to 1.25x, plus 3x on Bilt Travel hotels and 3x on Lyft,
+  still with no annual fee. Wells Fargo moved many existing holders into the
+  Autograph, which earns 3x on dining, travel, gas, transit, streaming, and
+  phone with no annual fee, and is the better landing spot if your spending
+  was never really about rent. If you want more from the Bilt ecosystem, the
+  $95 Obsidian keeps the rent earning while adding a choice of 3x dining or
+  groceries and better travel rates. Existing cardholders can keep using what
+  they have, but any new decision here is really a decision between those
+  three.

--- a/data/cards/bilt-obsidian.yaml
+++ b/data/cards/bilt-obsidian.yaml
@@ -10,21 +10,21 @@ annual_fee: 95
 reward_type: "points"
 release_date: "2025-01-15"
 our_take: >
-  Obsidian is the $95 middle rung of the Bilt lineup, and the reason to pay
-  that fee over the free Blue is the 3x category you choose each year: dining
-  by default or groceries instead, up to $25,000 of annual spend before it
-  drops to 1x, with up to 6x at participating Bilt Dining restaurants when
-  dining is selected. Travel earns better here too, at 4x on hotels and 3x on
-  flights through Bilt Travel, 2x on other travel, and 3x on Lyft rides after
-  you link the account, with no foreign transaction fee. Rent and mortgage
-  still pay with no transaction fee at up to 1.25x, though that rate only
-  applies on the housing-only track and is reset each billing cycle from your
-  everyday spend relative to the housing payment. The $100 hotel credit
-  arrives as two separate $50 statement credits and only counts on qualifying
-  Bilt Travel Portal bookings, so it is only worth the full amount if you book
-  hotels there twice a year. A $200 Bilt Cash welcome award with no minimum
-  spend covers the first year's fee on paper, but Bilt Cash spends inside
-  Bilt's ecosystem, not in your bank account.
+  Obsidian is the version of Bilt worth paying for if rent is a large line in
+  your budget: you keep fee-free housing payments earning up to 1.25x, and the
+  $95 annual fee is offset by a $100 Bilt Travel hotel credit issued as two
+  $50 statement credits. On top of that you choose 3x on either dining or
+  groceries each year, up to $25,000 in annual spend before it drops to 1x,
+  with dining reaching up to 6x at the limited network of participating Bilt
+  Dining restaurants. Travel earns well too: 4x on hotels and 3x on flights
+  through Bilt Travel, 2x on other travel, 3x on Lyft after linking your
+  account, and no foreign transaction fee. The caveats are the same ones that
+  apply across the Bilt lineup: the housing multiplier is recalculated each
+  billing cycle from your everyday spend, choosing the Bilt Cash track drops
+  housing to 1x, and the $200 signup bonus arrives as Bilt Cash rather than
+  money. Note also that the intro APR is 10% for 12 billing cycles rather than
+  0%, and the regular rate of 26.74% to 34.74% is high, so this is a card for
+  people who pay in full.
 benefits:
   - name: "Rent Payment Without Fees"
     value: 0

--- a/data/cards/bilt-palladium.yaml
+++ b/data/cards/bilt-palladium.yaml
@@ -7,23 +7,22 @@ apply_link: https://www.biltrewards.com/card/apply
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  Palladium is the $495 top of the Bilt lineup, and the case for it is the
-  credits rather than the earn rates: $400 in annual Bilt Travel hotel credit
-  paid as two $200 statement credits, plus $200 in annual Bilt Cash with up to
-  $100 rolling into the next year, alongside Priority Pass lounge access. It
-  is also the only Bilt card that earns 2x on everyday spend, with 4x on Bilt
-  Travel hotels, 3x on Bilt Travel flights, 4x on Lyft rides after linking
-  your account, and up to 5x at participating Bilt Dining restaurants, all
-  with no foreign transaction fee. The welcome offer is 50,000 points after
-  $4,000 in three months plus $300 in Bilt Cash, and hitting $4,000 in
-  non-housing spend within 90 days also triggers Gold Status. The honest
-  tradeoff is that the credits are the fee math: both hotel credits are locked
-  to Bilt Travel Portal bookings, Bilt Cash is an in-ecosystem currency rather
-  than cash back, and rent still earns only up to 1.25x on the housing track,
-  with the multiplier reset each cycle from your everyday spend. It ranks #14
-  on our Best Travel list, which is a fair reflection of a card that pays off
-  for people who book hotels through Bilt and use the lounge access, and not
-  for anyone else.
+  Palladium is the premium tier, and the credits are what make the $495 fee
+  defensible: $400 a year in Bilt Travel hotel credits issued as two $200
+  statement credits, plus $200 in annual Bilt Cash with up to $100 rolling
+  into the next year, alongside Priority Pass lounge access. It also carries
+  the best everyday rate in the Bilt lineup at 2x on all non-category spend,
+  on top of fee-free rent or mortgage payments earning up to 1.25x, 4x on Bilt
+  Travel hotels, 3x on flights, 4x on Lyft, and no foreign transaction fee,
+  which is enough to put it at #14 on our Best Travel Credit Cards list. The
+  signup bonus is 50,000 points after $4,000 in the first 3 months plus $300
+  in Bilt Cash, and hitting that same $4,000 in non-housing spend within 90
+  days earns Gold Status. The honest catch is that most of the fixed value is
+  locked inside Bilt's own ecosystem: the hotel credits only work on Bilt
+  Travel bookings and Bilt Cash is a separate currency aimed at buying point
+  accelerators, not real cash. Choosing the 4% Bilt Cash track also drops
+  housing earnings to 1x, so it is one track or the other, and the 26.74% to
+  34.74% regular APR means this only makes sense if you never carry a balance.
 annual_fee: 495
 reward_type: "points"
 release_date: "2025-01-15"

--- a/data/cards/blue-business-cash-card-from-american-express.yaml
+++ b/data/cards/blue-business-cash-card-from-american-express.yaml
@@ -32,14 +32,16 @@ apply_link: https://www.americanexpress.com/en-us/business/credit-cards/blue-bus
 foreign_transaction_fee: true
 network: "amex"
 our_take: >
-  The Blue Business Cash is the simplest version of a business card: 2% cash
-  back on everything with no categories to track and no annual fee, which is a
-  clean default for a business whose spending does not fit neatly into bonus
-  buckets. The 2% runs until $50,000 of purchases in a calendar year and then
-  drops to 1%, so it fits smaller operations better than high-volume ones. A
-  $250 welcome bonus after $3,000 in the first three months is modest but
-  reachable, and the 0% intro APR for 12 months gives you a window to finance
-  equipment or inventory without interest. The clear weakness is the foreign
-  transaction fee, which makes it a poor fit for any business buying from
-  overseas suppliers or traveling internationally. Also weigh Amex acceptance,
-  since a flat rate only helps where the card is taken.
+  This is one of the simplest business cards to justify: 2% cash back on all
+  eligible purchases up to $50,000 a year with no annual fee, which covers the
+  entire spending needs of most small operations without any category
+  tracking. Purchases above that $50,000 threshold drop to 1%, so the sweet
+  spot is a business spending somewhere under about $4,100 a month on the
+  card. There is a $250 bonus after $3,000 in the first 3 months and 12 months
+  of 0% intro APR on purchases, which is useful runway for equipment or
+  inventory before the regular 16.74% to 28.49% rate begins. Two real
+  limitations: it charges foreign transaction fees, so it is a poor fit for
+  any business buying internationally or traveling, and cash back is the only
+  currency, with no points to transfer or stretch. If you want the same 2x
+  earning in a form you can eventually move to travel partners, its sibling
+  Blue Business Plus is the better structure.

--- a/data/cards/blue-business-plus-credit-card-from-american-express.yaml
+++ b/data/cards/blue-business-plus-credit-card-from-american-express.yaml
@@ -32,14 +32,15 @@ apply_link: https://www.americanexpress.com/us/credit-cards/business/business-cr
 foreign_transaction_fee: true
 network: "amex"
 our_take: >
-  Blue Business Plus earns 2x points on all purchases with no annual fee,
-  which makes it a reasonable catch-all for business spending that does not
-  line up with any bonus category. That 2x applies to the first $50,000 of
-  purchases each calendar year and then falls to 1x, so the value is real for
-  small and mid-size spenders and thins out above that. The welcome offer is
-  15,000 points after $3,000 in the first three months, and the 0% intro APR
-  for 12 months gives some breathing room on a large startup purchase. The
-  tradeoff worth naming is the foreign transaction fee, which undercuts the
-  card for any business with overseas suppliers or international travel. If
-  you would rather have flat cash back than points, the Blue Business Cash
-  version pays 2% under the same cap and fee structure.
+  The core of this card is flat 2x Membership Rewards points on all eligible
+  purchases up to $50,000 a year with no annual fee, which is unusually good
+  for a business card that costs nothing to hold. Points are the reason to
+  prefer it over a plain cash back card, since Membership Rewards can be moved
+  to transfer partners rather than only redeemed against your statement, so
+  the effective return depends on how you use them. Above $50,000 in annual
+  spend the rate falls to 1x, meaning this is best suited to businesses
+  spending roughly $4,100 a month or less on the card. New cardholders get
+  15,000 points after $3,000 in the first 3 months, and there are 12 months of
+  0% intro APR on purchases before the regular 16.74% to 28.49% rate takes
+  over. The one clear gap is foreign transaction fees, which makes it the
+  wrong card for international purchases or business travel abroad.

--- a/data/cards/blue-cash-everyday-card.yaml
+++ b/data/cards/blue-cash-everyday-card.yaml
@@ -8,20 +8,18 @@ foreign_transaction_fee: true
 network: "amex"
 card_referral_link: "https://americanexpress.com/en-us/referral/blue-cash-everyday-credit-card?ref="
 our_take: >
-  Blue Cash Everyday covers the three places most households actually spend at
-  3%: U.S. supermarkets, U.S. gas stations, and U.S. online retail, each with
-  its own $6,000 annual cap before dropping to 1%, and it charges no annual
-  fee. Fully used, those caps are worth up to $540 a year in bonus cash back,
-  which is a lot for a card that costs nothing to hold. It also carries one of
-  the longer intro windows in the no-fee cash back tier at 0% for 15 months on
-  both purchases and balance transfers, with transfers needing to be requested
-  within 60 days of opening. The catches are ordinary but worth knowing:
-  everything outside those three categories earns 1%, there is a foreign
-  transaction fee that rules it out abroad, and the $84 in annual Disney
-  streaming credit comes as $7 monthly increments you have to enroll for and
-  actually use. It sits at #6 on our Best Cash Back list, and the $200 welcome
-  bonus after $2,000 in six months is an easy target for a card you would
-  carry anyway.
+  The Blue Cash Everyday spreads 3% cash back across three categories most
+  households already spend in: U.S. supermarkets, U.S. gas stations, and U.S.
+  online retail, all with no annual fee. The limit is the cap: each category
+  earns 3% on only the first $6,000 a year, and everything past that, plus all
+  other spending, drops to 1%. New cardholders can pick up $200 after $2,000
+  of spend in the first 6 months, and there's a 15 month 0% intro APR on both
+  purchases and balance transfers requested within 60 days, which gives the
+  card a second use as a short payoff runway. The $7 monthly credit toward
+  Disney+, Hulu, or ESPN+ is worth up to $84 a year but requires enrollment,
+  so it only counts if you already pay for one of those. Note the foreign
+  transaction fee: this is a domestic card, and it ranks #6 on our Best Cash
+  Back list.
 annual_fee: 0
 reward_type: "cashback"
 tags:

--- a/data/cards/blue-cash-preferred-card.yaml
+++ b/data/cards/blue-cash-preferred-card.yaml
@@ -7,20 +7,18 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/blue-cash-prefe
 foreign_transaction_fee: true
 network: "amex"
 our_take: >
-  The Blue Cash Preferred is built around one very strong rate: 6% back at
-  U.S. supermarkets on the first $6,000 each year, worth up to $360 before it
-  steps down to 1%, which is why it ranks #2 on our Best Cards for Dining and
-  Groceries list. The 6% on select U.S. streaming subscriptions is the other
-  standout, and 3% on gas and 3% on transit including rideshare, parking,
-  tolls, and transit fares round it out well for a household in the suburbs or
-  a city. The $95 annual fee is the honest tradeoff, and the math is simple:
-  roughly $1,600 a year at supermarkets covers it, so heavy grocery spenders
-  clear it easily and light ones should look at the no-fee Blue Cash Everyday
-  instead. There is also a $7 monthly credit toward the Disney Bundle that
-  needs enrollment, plus purchase protection, return protection, and extended
-  warranty coverage. Two limits to plan around: everything outside the bonus
-  categories earns just 1%, and the foreign transaction fee makes this a
-  domestic card only.
+  The reason to carry the Blue Cash Preferred is the 6% back at U.S.
+  supermarkets, the highest grocery rate we track, which is why it sits at #1
+  on our Best Credit Cards for Dining and Groceries list. That 6% applies to
+  the first $6,000 of grocery spend each year and then falls to 1%, so the
+  ceiling is $360 in grocery rewards annually, against a $95 annual fee.
+  Select U.S. streaming subscriptions also earn 6%, with 3% on transit and
+  U.S. gas stations and 1% on everything else. The math works if you spend
+  enough on groceries to clear the fee, and it gets thin fast if you don't.
+  There's $300 back after $3,000 in 6 months and a 12 month 0% intro APR on
+  purchases and on balance transfers requested within 60 days, plus purchase,
+  return, and extended warranty protection, though the foreign transaction fee
+  makes this a card to leave home when you travel abroad.
 annual_fee: 95
 reward_type: "cashback"
 rewards:

--- a/data/cards/british-airways-visa-signature-card.yaml
+++ b/data/cards/british-airways-visa-signature-card.yaml
@@ -75,20 +75,16 @@ benefits:
     category: "protection"
     enrollment_required: false
 our_take: >
-  The reason to carry this card is the reward flight statement credits: up to
-  three per year, $100 for Economy or Premium Economy and $200 for Business or
-  First, applied against the taxes and carrier charges on British Airways
-  reward flights, which is a direct answer to the biggest complaint about
-  redeeming Avios. Add a 75,000 Avios welcome bonus after $5,000 in three
-  months, no foreign transaction fee, and 10% off British Airways flights from
-  the US to London booked through the cardmember site, and the $95 annual fee
-  is easy to justify if you fly BA even once a year. Earning is narrow,
-  though: the 3x rate applies only to British Airways, Aer Lingus, and Iberia
-  purchases, hotels booked directly earn 2x, and everything else is a flat 1x,
-  so this is not a card for daily spend. The Travel Together Ticket sounds
-  like the headline perk, but it takes $30,000 of spend in a calendar year to
-  unlock, which puts it out of reach for most cardholders. Also included are a
-  DashPass membership when activated by the end of 2027, baggage delay and
-  lost luggage coverage, and purchase protection, and the card sits at #3 on
-  our Best Airline Cards list.
+  The draw here is the 75,000 Avios signup bonus after $5,000 of spend in 3
+  months, a large opening haul for a $95 annual fee, and the reason this card
+  ranks #3 on our Best Airline Credit Cards list. Ongoing earning is narrow:
+  3x applies only to British Airways, Aer Lingus, and Iberia flights, with 2x
+  on hotels booked directly and 1x on everything else, so it isn't a card for
+  daily spend. What keeps it useful past year one is the reward flight
+  statement credits, up to three per year at $100 for Economy or Premium
+  Economy and $200 for Business or First, applied to the taxes and carrier
+  charges that make Avios redemptions expensive. The Travel Together Ticket
+  sounds better than it plays for most people, since it takes $30,000 of spend
+  in a calendar year to earn. No foreign transaction fee is the right call for
+  a card built around transatlantic flying.
 apply_link: https://creditcards.chase.com/travel-credit-cards/british-airways

--- a/data/cards/capital-one-platinum-secured.yaml
+++ b/data/cards/capital-one-platinum-secured.yaml
@@ -15,14 +15,15 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/platinum-secured/
 foreign_transaction_fee: false
 our_take: >
-  The Platinum Secured is a low-cost way into the Capital One ecosystem when
-  you need a deposit-backed card: no annual fee, no foreign transaction fee,
-  and a spot at #6 on our Best Secured Credit Cards list. Paying nothing to
-  hold it matters here, because the whole point is to keep the card open long
-  enough to build a payment history without bleeding fees. The tradeoff is
-  that it earns no rewards whatsoever, so it is a credit-building tool and
-  nothing more. At a 28.99% APR, any balance you carry will erase whatever
-  progress the card is helping you make, so treat it as a pay-in-full card
-  only. If you want cash back while you build, the Quicksilver Secured is the
-  same idea with a 1.5% earn rate attached.
+  The Platinum Secured is a credit-building tool, not a rewards card: you put
+  down a refundable security deposit, use the account responsibly, and let the
+  payment history do the work, all with no annual fee. That zero fee matters
+  more than it sounds, because plenty of secured cards charge one, and it's
+  why the card holds #6 on our Best Secured Credit Cards list. Be clear about
+  what you're not getting: there is no cash back, no points, and no signup
+  bonus, so every dollar you put through it earns nothing. The APR is a flat
+  28.99%, which makes carrying a balance genuinely expensive and defeats the
+  purpose of building credit here. There's no foreign transaction fee, a small
+  bonus if you travel while rebuilding. Use it for a small recurring charge,
+  pay in full monthly, and graduate to something that earns.
 

--- a/data/cards/capital-one-platinum.yaml
+++ b/data/cards/capital-one-platinum.yaml
@@ -14,13 +14,12 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/platinum/
 foreign_transaction_fee: false
 our_take: >
-  The Platinum is a plain credit-building card: no annual fee, no foreign
-  transaction fee, and a straightforward path to a Capital One account if your
-  file is thin or damaged. That combination makes it cheap to hold while you
-  establish a payment history, and the lack of a foreign transaction fee is a
-  nice bonus at this tier. The catch is that it earns nothing at all: there is
-  no cash back, no points, and no signup bonus, so every dollar you spend on
-  it does only one job, which is reporting on-time payments. The 28.99% APR is
-  high enough that carrying a balance would quickly cost more than the card is
-  worth, so pay in full every month. Use it to build, then move to a rewards
-  card once you qualify.
+  The Platinum's whole pitch is access: no annual fee, no security deposit,
+  and a straightforward path to establishing or rebuilding credit with a major
+  issuer. Take it for what it is, because it earns nothing. There is no cash
+  back, no points, no signup bonus, and no intro APR, so this card gives you a
+  tradeline and little else. The 28.99% APR is flat regardless of your
+  profile, which makes any carried balance costly and means the only sensible
+  way to use it is paying in full every month. The lack of a foreign
+  transaction fee is a genuine if minor perk. Once your credit supports a
+  rewards card, there's no reason to keep spending on this one.

--- a/data/cards/capital-one-quicksilver-secured.yaml
+++ b/data/cards/capital-one-quicksilver-secured.yaml
@@ -23,14 +23,14 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/quicksilver-secured/
 foreign_transaction_fee: false
 our_take: >
-  This is the rare secured card that actually pays you while you rebuild: a
-  flat 1.5% cash back on everything, no annual fee, and no foreign transaction
-  fee, which is why it ranks #3 on our Best Secured Credit Cards list with a
-  Best Value badge. Most deposit-backed cards earn nothing, so getting an
-  unlimited 1.5% return with zero carrying cost is the strongest argument
-  here. The 5% rate is narrower than it looks: it only covers hotels and
-  rental cars booked through Capital One Travel, so 1.5% is your true base.
-  The real cost is the security deposit you have to tie up, plus a 28.99% APR
-  with no intro period, which means this card only works if you pay in full
-  every month. Build your history, earn a little back along the way, and
-  graduate when Capital One offers you an unsecured product.
+  This is the rare secured card that actually earns: a flat 1.5% back on every
+  purchase with no annual fee, which is why it carries the Best Flat Rate
+  badge at #3 on our Best Secured Credit Cards list. For someone building or
+  rebuilding credit, that combination of a refundable deposit and real ongoing
+  rewards beats most of the field, and there's no foreign transaction fee.
+  Hotels and rental cars booked through Capital One Travel earn 5%, though
+  that's a narrow channel most cardholders won't use often. The catch is the
+  28.99% APR, flat for everyone, with no intro period to soften it, so this
+  card only makes sense if you pay in full each month. There's also no signup
+  bonus, so the value is entirely in the 1.5% and the credit history you're
+  building.

--- a/data/cards/capital-one-quicksilver.yaml
+++ b/data/cards/capital-one-quicksilver.yaml
@@ -34,18 +34,17 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/quicksilver/
 foreign_transaction_fee: false
 our_take: >
-  The Quicksilver's appeal is simplicity: a flat 1.5% cash back on everything
-  with no annual fee and no foreign transaction fee, so there are no
-  categories to track or activate. It also comes with 15 months of 0% intro
-  APR on both purchases and balance transfers, which is a genuinely useful
-  window if you have a large purchase or existing balance to clear, and a $200
-  bonus after $500 in spending within the first 3 months is easy to hit. The
-  5% rate applies only to hotels and rental cars booked through Capital One
-  Travel, so treat 1.5% as the real everyday rate. That flat rate is the
-  honest limitation: category cards will out-earn it on dining, groceries, and
-  gas, which is part of why it lands at #8 on our Best Cash Back Credit Cards
-  list rather than higher. Price Drop Protection and the price match guarantee
-  are minor extras tied to booking through Capital One Travel.
+  The Quicksilver is a set-and-forget flat-rate card: 1.5% back on everything,
+  no annual fee, no categories to track or activate, and no foreign
+  transaction fee. The 15 month 0% intro APR on both purchases and balance
+  transfers is the underrated part, giving it a second life as a payoff or
+  large-purchase card before the 18.49% to 28.49% regular rate kicks in. The
+  $200 bonus after just $500 of spend in 3 months is one of the easiest
+  thresholds around. The honest limitation is the earn rate itself: 1.5%
+  trails the 2% flat-rate cards and loses badly to category cards on groceries
+  and dining, which is why it lands at #8 on our Best Cash Back list rather
+  than higher. The 5% on hotels and rental cars booked through Capital One
+  Travel is real but only pays off if you book through that portal.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/capital-one-quicksilverone.yaml
+++ b/data/cards/capital-one-quicksilverone.yaml
@@ -20,13 +20,13 @@ apr:
     max: 28.99
 apply_link: https://www.capitalone.com/credit-cards/quicksilverone/
 our_take: >
-  The QuicksilverOne offers a flat 1.5% cash back on everything with no
-  foreign transaction fee, aimed at people with fair credit who cannot yet
-  qualify for the no-fee Quicksilver. The catch is the $39 annual fee, which
-  means you need to spend about $2,600 a year just to break even on the
-  rewards before the card earns you anything. The 5% rate covers only hotels
-  and rental cars booked through Capital One Travel, so do not count it as
-  part of your everyday return. There is also no signup bonus and no intro APR
-  window, and the 28.99% regular APR leaves no room to carry a balance. If
-  your credit supports the no-fee Quicksilver, take that instead; this version
-  makes sense mainly as a stepping stone.
+  The QuicksilverOne exists for people who can't yet qualify for the no-fee
+  flat-rate cards: it pays 1.5% back on everything with a $39 annual fee and
+  no foreign transaction fee. That fee means you need roughly $2,600 of annual
+  spend just to break even against the rewards, so run that math before you
+  apply. There's no signup bonus and no intro APR, and the regular APR is a
+  flat 28.99%, which makes carrying a balance the fastest way to erase any
+  value the card produces. Hotels and rental cars booked through Capital One
+  Travel earn 5%, but that's a narrow lane. Treat this as a stepping stone:
+  use it to build history, then move to a version of the same 1.5% with no
+  annual fee.

--- a/data/cards/capital-one-savor-student.yaml
+++ b/data/cards/capital-one-savor-student.yaml
@@ -42,17 +42,17 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/savor-student/
 foreign_transaction_fee: false
 our_take: >
-  For a student card, the earn structure is unusually generous: 3% back on
-  dining, entertainment, streaming, and groceries with no annual fee and no
-  foreign transaction fee, which fits both campus spending and a semester
-  abroad. The signup bonus was doubled from $50 to $100 in June, and the $300
-  spending requirement over 3 months is realistic on a student budget. The
-  limitation is everything else earning 1%, plus a 5% rate that only applies
-  to hotels and rental cars booked through Capital One Travel. There is also
-  no intro APR period here, and the regular rate runs from 18.49% to 28.49%,
-  so this card assumes you are paying the statement in full each month. As a
-  first card that builds credit and pays real cash back on the categories
-  students actually use, it holds up well.
+  For a student card, the earning structure is unusually broad: 3% back on
+  dining, entertainment, streaming, and groceries, four categories that cover
+  most of a student budget, with no annual fee. Capital One recently doubled
+  the signup bonus from $50 to $100, and the $300 spend requirement over 3
+  months is low enough that almost anyone will clear it. Hotels and rental
+  cars booked through Capital One Travel earn 5%, and there's no foreign
+  transaction fee, which makes this a reasonable card to carry while studying
+  abroad. The tradeoff is everything outside those categories earns just 1%,
+  and there's no intro APR window, so the 18.49% to 28.49% regular rate
+  applies from day one. Pay in full each month and this is a solid first card
+  that doesn't need to be replaced the day you graduate.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/capital-one-savor.yaml
+++ b/data/cards/capital-one-savor.yaml
@@ -49,17 +49,19 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/savor/
 foreign_transaction_fee: false
 our_take: >
-  The Savor covers most of a typical household's discretionary spending at 3%:
-  dining, entertainment, groceries, and streaming, all with no annual fee and
-  no foreign transaction fee. For a card that costs nothing to hold, that is a
-  wide bonus footprint, and 12 months of 0% intro APR on purchases and balance
-  transfers gives you some breathing room early on. Worth knowing before you
-  apply: the signup bonus rose to $250 in June and was cut back to $200 on
-  August 12, so you are looking at $200 after $500 in spending within 3 months
-  rather than the better offer some write-ups still cite. The weak spot is
-  everything outside those categories, which earns just 1%, and the 5% rate
-  applies only to hotels and rental cars booked through Capital One Travel.
-  Pair it with a flat-rate card for non-bonus spending and it works well.
+  The Savor gets you 3% back on dining, entertainment, streaming, and
+  groceries with no annual fee, which is a genuinely strong set of everyday
+  categories to cover for free. Capital One raised the signup bonus to $250 in
+  June and then pulled it back to $200 in August, so what's on the table now
+  is $200 after $500 of spend in 3 months, still an easy threshold. There's a
+  12 month 0% intro APR on purchases and balance transfers before the 18.49%
+  to 28.49% regular rate, and no foreign transaction fee. The limits are worth
+  naming: everything outside the bonus categories earns 1%, and the headline
+  8% rate applies only to Capital One Entertainment bookings, not
+  entertainment spending generally, the same way the 5% is confined to hotels
+  and rental cars booked through Capital One Travel. If your spending clusters
+  in food and entertainment, the no-fee structure makes this hard to argue
+  with.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/capital-one-savorone.yaml
+++ b/data/cards/capital-one-savorone.yaml
@@ -41,15 +41,14 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/savorone/
 foreign_transaction_fee: false
 our_take: >
-  The SavorOne earns 3% back across dining, entertainment, streaming, and
-  groceries, a bonus lineup broad enough to cover most of what a household
-  spends outside of bills, and it ranks #4 on our Best Credit Cards for Dining
-  and Groceries list. It also carries 12 months of 0% intro APR on purchases
-  and balance transfers, useful if you are financing something early in the
-  card's life. The catch is the $39 annual fee paired with no signup bonus at
-  all, so nothing offsets that cost up front and you need roughly $1,300 of
-  annual bonus-category spending just to break even. Everything outside the 3%
-  categories earns 1%, and the regular APR of 18.49% to 28.49% leaves little
-  room to carry a balance past the intro window. If you can qualify for a
-  no-fee card with the same categories, that is the better version of this
-  idea.
+  The SavorOne earns 3% on dining, entertainment, streaming, and groceries, a
+  strong everyday spread that puts it at #5 on our Best Credit Cards for
+  Dining and Groceries list. The complication is the $39 annual fee: you need
+  about $1,300 of bonus-category spend a year just to cover it, and there's no
+  signup bonus to offset the first year. A 12 month 0% intro APR on purchases
+  and balance transfers gives you a payoff runway before the 18.49% to 28.49%
+  regular rate applies, and there's no foreign transaction fee. Everything
+  outside the four bonus categories earns 1%, so this is a card that rewards
+  concentrated spending and punishes scattered spending. Check whether you
+  qualify for a no-fee version of the same category structure before paying
+  the $39.

--- a/data/cards/capital-one-spark-cash-plus.yaml
+++ b/data/cards/capital-one-spark-cash-plus.yaml
@@ -73,16 +73,15 @@ benefits:
     category: "other"
 apply_link: https://www.capitalone.com/small-business/credit-cards/spark-cash-plus/
 our_take: >
-  Spark Cash Plus pays a flat 2% on every business purchase with no category
-  tracking, and the $150 annual fee is refunded in full any year you spend at
-  least $150,000, which effectively makes it free for higher-volume
-  businesses. The signup offer is one of the largest here: $2,000 cash after
-  $30,000 in the first 3 months, plus a limited-time $500 Capital One Business
-  Travel credit on that same spend, and the card keeps paying $2,000 for every
-  $500,000 spent in the first year. Employee cards are free and earn on the
-  primary account, and there is no foreign transaction fee. The structural
-  catch is that this is a pay-in-full charge product: there is no preset
-  spending limit, but the balance is due every month, so it cannot be used to
-  float expenses. The 5% rate applies only to hotels, vacation rentals, and
-  rental cars booked through Capital One Business Travel, so 2% is the real
-  everyday rate.
+  The Spark Cash Plus earns a flat 2% cash back on everything with no category
+  tracking, which makes it a straightforward fit for a business with heavy,
+  unpredictable spend. Capital One also refunds the $150 annual fee in any
+  year you charge at least $150,000, and pays a $2,000 bonus for every
+  $500,000 spent in the first year, so the card is built around volume rather
+  than optimization. The signup bonus is $2,000 after $30,000 in the first 3
+  months, currently paired with a limited-time $500 Capital One Business
+  Travel credit on the same spend. The catch is the structure: this is a
+  charge card with no preset spending limit, meaning the balance is due in
+  full every month, so it only works if your cash flow can cover it. If your
+  spend is modest, the $150 fee is real money and the 2% rate alone may not
+  clear it.

--- a/data/cards/capital-one-spark-classic.yaml
+++ b/data/cards/capital-one-spark-classic.yaml
@@ -58,14 +58,15 @@ benefits:
     category: "other"
 apply_link: https://www.capitalone.com/small-business/credit-cards/spark-classic/
 our_take: >
-  Spark Classic exists for business owners with limited or damaged credit who
-  still want a card that reports and pays something: unlimited 1% cash back
-  with no minimum to redeem, no annual fee, and no foreign transaction fee.
-  Free employee cards that earn on the primary account and virtual card
-  numbers are useful additions at a $0 cost, and being able to pick your due
-  date helps with cash flow timing. The honest assessment is that 1% is a weak
-  return in a market where 2% flat-rate business cards are common, so this is
-  a credit-building card first and a rewards card a distant second. There is
-  no signup bonus and no intro APR, and the 28.99% regular rate makes carrying
-  a balance expensive. Use it to establish business credit, then move to a 2%
-  card once you qualify.
+  The Spark Classic exists for business owners with fair or rebuilding credit,
+  and it is honest about that: no annual fee, unlimited 1% cash back on
+  everything, no minimum to redeem and no expiration while the account is
+  open. Free employee cards, virtual card numbers, and year-end spending
+  summaries that export to QuickBooks give it enough utility to run a small
+  business through. The tradeoff is the price of admission elsewhere: 1% is
+  well below what most business cards pay, and the 28.99% regular APR means
+  carrying a balance will erase the rewards many times over. There is no
+  signup bonus and no intro APR window, so nothing here rewards you for
+  opening it beyond the account itself. Use it to build business credit
+  history, pay in full every month, and plan to move to a 2% card once your
+  profile supports one.

--- a/data/cards/capital-one-venture-business.yaml
+++ b/data/cards/capital-one-venture-business.yaml
@@ -59,15 +59,15 @@ apr:
 apply_link: https://www.capitalone.com/small-business/credit-cards/venture-business/
 foreign_transaction_fee: false
 our_take: >
-  The pitch here is simplicity: 2x miles on every business purchase with no
-  category tracking, for a $95 annual fee and no foreign transaction fees. The
-  signup bonus of 100,000 miles after $10,000 in three months is the other
-  draw, though it has been volatile lately, rising from 75,000 to 150,000 in
-  June before settling back to 100,000 in July. The 5x rate is narrower than
-  it looks: it applies only to hotels, vacation rentals, and rental cars
-  booked through Capital One Business Travel, so most spending lands at the 2x
-  base. Small credits help chip at the fee, with $50 a year toward Capital One
-  Business Travel, up to $50 for software and advertising, and up to $120 for
-  Global Entry or TSA PreCheck every four years. Free employee cards that earn
-  on the primary account make it easier to hit that $10,000 threshold if you
-  have a team spending alongside you.
+  Venture Business pairs a flat 2x miles on every purchase with a 100,000-mile
+  signup bonus after $10,000 in the first 3 months, which is a lot of value
+  for a $95 annual fee. Bookings through Capital One Business Travel earn 5x
+  on hotels, vacation rentals, and rental cars, and the card layers on a $50
+  annual Business Travel credit, up to $50 a year in software and advertising
+  credits, and a Global Entry or TSA PreCheck credit every 4 years. Employee
+  cards are free and earn miles on the primary account, and there are no
+  foreign transaction fees. Be aware the bonus has moved twice recently: it
+  climbed from 75,000 to 150,000 miles in June, then settled back to 100,000
+  in July, so the current offer is well off the peak. The $10,000 spend
+  requirement is also steep for a smaller business, and at 24.49% APR this is
+  a pay-in-full card.

--- a/data/cards/capital-one-venture-rewards.yaml
+++ b/data/cards/capital-one-venture-rewards.yaml
@@ -53,16 +53,14 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/venture/
 foreign_transaction_fee: false
 our_take: >
-  Venture Rewards earns 2x miles on everything with a $95 annual fee and no
-  foreign transaction fees, which is the cleanest version of the flat-rate
-  travel card and enough to place it seventh on our Best Travel Credit Cards
-  list. The current offer is 75,000 miles after $4,000 in three months plus a
-  $250 travel credit in your first cardholder year, which more than covers the
-  fee up front. Be honest about the bonus categories before you count on them:
-  the 5x rates apply only to hotels and rental cars booked through Capital One
-  Travel and to tickets bought on the Capital One Entertainment platform, not
-  to travel or entertainment generally. Ongoing perks are modest, mainly up to
-  $120 for Global Entry or TSA PreCheck every four years and a $50 experience
-  credit on Lifestyle Collection stays. If you want one card that earns a
-  solid flat rate on every purchase abroad and at home, this does that job
-  without asking you to think about it.
+  The Venture's appeal is simplicity: 2x miles on every purchase with no
+  categories to track, for a $95 annual fee and no foreign transaction fees.
+  The current offer is 75,000 miles after $4,000 in 3 months plus a $250
+  travel credit in the first cardholder year, which more than covers the fee
+  up front. A Global Entry or TSA PreCheck credit of up to $120 every 4 years
+  is the most useful ongoing perk, and it currently sits at #8 on our Best
+  Travel Credit Cards list. Read the higher rates carefully: the 5x on hotels
+  and rental cars applies only to bookings made through Capital One Travel,
+  and the 5x entertainment rate is limited to the Capital One Entertainment
+  platform, not entertainment spending generally. If you already book travel
+  elsewhere, treat 2x as the card's real everyday rate and judge it on that.

--- a/data/cards/capital-one-venture-x-business.yaml
+++ b/data/cards/capital-one-venture-x-business.yaml
@@ -72,18 +72,16 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  This is the business version of the premium Capital One playbook: a $395
-  annual fee largely neutralized by a $300 annual credit for bookings through
-  Capital One Business Travel and 10,000 anniversary miles, plus lounge access
-  for the primary cardholder at Capital One Lounges, Landings, and Priority
-  Pass. Everything earns 2x miles including employee card spending, and
-  employee and virtual cards are unlimited and free, which makes it a
-  reasonable single card for a company that does not want to police
-  categories. The signup bonus is large at 150,000 miles, but so is the
-  hurdle: $30,000 in three months, and it is closed to existing or previous
-  Capital One business cardholders. The 10x and 5x rates are portal-only,
-  covering hotels and rental cars or flights and vacation rentals booked
-  through Capital One Business Travel, so treat 2x as the real earn rate. One
-  detail worth knowing before you bring colleagues to the lounge:
-  complimentary guest access does not unlock until you spend $75,000 in a
-  year.
+  Venture X Business is built for a company that actually spends: 150,000
+  miles after $30,000 in the first 3 months, 2x miles on everything, and 10x
+  on hotels and rental cars booked through Capital One Business Travel. The
+  $395 annual fee is largely offset in practice by the $300 annual travel
+  credit and 10,000 anniversary miles, and the card adds Capital One Lounge
+  and Priority Pass access, a Global Entry or TSA PreCheck credit, Hertz
+  President's Circle status, and unlimited free employee cards that also earn
+  2x. The conditions are where it gets narrower: the signup bonus is closed to
+  existing and previous Capital One business cardholders, complimentary lounge
+  guest access only unlocks after $75,000 in annual spend, and the $300 credit
+  is usable only inside Capital One Business Travel. That $30,000 in 90 days
+  is a real hurdle for a smaller operation. If your travel does not route
+  through Capital One's portal, the effective value drops quickly.

--- a/data/cards/capital-one-venture-x.yaml
+++ b/data/cards/capital-one-venture-x.yaml
@@ -113,18 +113,17 @@ apply_link: https://www.capitalone.com/credit-cards/venture-x/
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  Venture X is the rare premium card where the math works without much effort:
-  the $395 annual fee is offset by a $300 annual travel credit through Capital
-  One Travel and 10,000 anniversary miles, so the effective cost is close to
-  nothing if you book any travel through the portal. Lounge access is the
-  other real draw, covering Capital One Lounges plus a Priority Pass Select
-  membership good at 1,300 or more locations, and it ranks fifth on our Best
-  Travel Credit Cards list with the Best Premium badge. Everyday earning is a
-  flat 2x miles on all purchases with no foreign transaction fees, and the
-  headline 10x and 5x rates apply only inside Capital One's own channels:
-  hotels and rental cars, flights, and tickets on the Capital One
-  Entertainment platform. The signup bonus is 75,000 miles after $4,000 in
-  three months, solid but not the reason to pick this card. The catch is that
-  the value is concentrated in the portal, so if you refuse to book travel
-  through Capital One, you are paying $395 mostly for lounges and a 2x base
-  rate.
+  Venture X is the rare premium travel card whose math mostly works on its
+  own: the $300 annual travel credit plus 10,000 anniversary miles roughly
+  cancel the $395 annual fee before you count anything else. On top of that
+  you get Capital One Lounge access, Priority Pass Select, a Global Entry or
+  TSA PreCheck credit, cell phone protection up to $800, and 2x miles on every
+  purchase, which is why it sits at #3 with a Best Value badge on our Best
+  Travel Credit Cards list and #7 for signup bonuses. The current offer is
+  75,000 miles after $4,000 in 3 months. The important caveat is that the
+  headline rates and the $300 credit are portal-bound: 10x on hotels and
+  rental cars and 5x on flights require booking through Capital One Travel,
+  and the 5x entertainment rate applies only to Capital One Entertainment
+  purchases, not entertainment spending in general. If you are unwilling to
+  book inside Capital One's portal, this becomes a 2x card with good lounge
+  access, which is still defensible but a different value proposition.

--- a/data/cards/capital-one-ventureone-business.yaml
+++ b/data/cards/capital-one-ventureone-business.yaml
@@ -67,16 +67,15 @@ benefits:
     category: "travel"
 apply_link: https://www.capitalone.com/small-business/credit-cards/ventureone-business/
 our_take: >
-  VentureOne Business earns 1.5x miles on every purchase with no annual fee
-  and no foreign transaction fees, which makes it a low-commitment way to keep
-  business spending in the Capital One miles ecosystem. The 50,000-mile bonus
-  after $4,500 in three months is generous for a card that costs nothing to
-  hold, and those miles transfer to more than 15 airline and hotel programs or
-  can be applied against travel purchases as a statement credit. The tradeoff
-  is that 1.5x is a step down from the 2x on the paid Venture Business card,
-  so if your spending is heavy enough, the $95 version likely wins on earn
-  rate alone. The 5x rate is limited to hotels, vacation rentals, and rental
-  cars booked through Capital One Business Travel, not travel in general. Free
-  employee cards with spending limits, Hertz Five Star status, and a regular
-  APR starting at 16.74% round it out as a sensible starter business card
-  rather than a primary one.
+  VentureOne Business earns 1.5x miles on everything with no annual fee and no
+  foreign transaction fees, which makes it a low-commitment way to put
+  business spend into Capital One miles that transfer to more than 15 airline
+  and hotel programs. The 50,000-mile signup bonus after $4,500 in 3 months is
+  generous for a card that costs nothing to keep, and free employee cards earn
+  miles on the primary account. It also carries a lower starting APR than most
+  Capital One business cards, at 16.74% to 22.74%. The tradeoff is the earn
+  rate: 1.5x is a step down from the 2x on the fee-carrying Venture Business,
+  so if your annual spend is meaningful the $95 card will out-earn this one
+  even after its fee. The 5x rate applies only to hotels, vacation rentals,
+  and rental cars booked through Capital One Business Travel, so treat 1.5x as
+  the card's real everyday rate.

--- a/data/cards/capital-one-ventureone-rewards.yaml
+++ b/data/cards/capital-one-ventureone-rewards.yaml
@@ -31,16 +31,17 @@ apr:
 apply_link: https://www.capitalone.com/credit-cards/ventureone/
 foreign_transaction_fee: false
 our_take: >
-  VentureOne is the no-annual-fee entry point to Capital One miles: 1.25x on
-  every purchase, no foreign transaction fees, and 15 months of 0% intro APR
-  on purchases if you have something to finance. The 20,000-mile bonus asks
-  only $500 of spending in three months, which is one of the easier thresholds
-  you will find. The honest problem is the earn rate, since 1.25x trails the
-  2x on the $95 Venture Rewards by enough that the fee usually pays for itself
-  once you are spending real money on the card. The 5x rate applies only to
-  hotels and rental cars booked through Capital One Travel, so most purchases
-  sit at that 1.25x base. Take this if you want a free card for overseas
-  spending and a long intro window, and move up if it becomes your main card.
+  VentureOne is the entry-level Venture: 1.25x miles on every purchase, no
+  annual fee, and no foreign transaction fees, which makes it a reasonable
+  first travel card or a keeper for the credit history once you upgrade past
+  it. It also carries 15 months of 0% intro APR on purchases, so it can double
+  as a way to finance something without paying interest. The 20,000-mile
+  signup bonus needs only $500 in spend over 3 months, one of the lower bars
+  around. The honest limitation is the earn rate: 1.25x trails the 2x on the
+  $95 Venture, and the 5x on hotels and rental cars requires booking through
+  Capital One Travel, so most spending lands at the base rate. Price
+  protection perks aside, this is a card you carry for the zero fee and the
+  intro window rather than for what it earns.
 benefits:
   - name: "Price Drop Protection"
     value: 0

--- a/data/cards/cash-magnet-card.yaml
+++ b/data/cards/cash-magnet-card.yaml
@@ -13,12 +13,13 @@ rewards:
 apply_link: https://www.americanexpress.com/us/credit-cards/card/cash-magnet/
 network: "amex"
 our_take: >
-  Cash Magnet was a straightforward flat-rate card: 1.5% unlimited cash back
-  on all eligible purchases with no annual fee, and nothing else to track.
-  American Express no longer accepts applications for it, so this page is
-  mainly useful to existing cardholders deciding whether to keep it. If you
-  still carry one, the calculus is simple: it costs nothing to hold and adds a
-  little to your average account age, but 1.5% is now the floor rather than
-  the standard for no-fee cash back. There are no bonus categories, credits,
-  or travel perks to weigh against that. Worth keeping open for the credit
-  history, not worth putting your everyday spending on.
+  The Cash Magnet's pitch was simplicity: a flat 1.5% cash back on all
+  eligible purchases with no annual fee and no categories to manage. American
+  Express is no longer accepting applications for it, so this is now a card
+  you can only evaluate if you already hold one. If you do, it still works as
+  a fine catch-all for spending that does not fall into a bonus category on
+  another card, and there is no fee pushing you to close it. Just note that
+  1.5% has become the floor rather than the standard among no-fee cash back
+  cards, and several flat-rate competitors now pay 2%. Keep it open for the
+  account age if you like, but there is no reason to route meaningful spend to
+  it.

--- a/data/cards/chase-aeroplan.yaml
+++ b/data/cards/chase-aeroplan.yaml
@@ -74,17 +74,16 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/aircanada/aeroplan
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Aeroplan card is built around Air Canada loyalty, and the benefits carry
-  more weight than the earn rate: a free first checked bag for you and up to
-  eight companions, plus two years of Aeroplan 25K Elite Status for new
-  cardmembers, on a $95 annual fee with no foreign transaction fees. Earning
-  is 3x points on dining and groceries, which is genuinely useful, and 3x on
-  Air Canada purchases made directly with the airline, with everything else at
-  1x. Chase recently cut the signup bonus from 75,000 points to 60,000 after
-  $3,000 in three months, so this is a weaker moment to apply than it was in
-  the spring. The monthly spend bonus is small but real, at 500 points for
-  every $2,000 spent up to 1,500 points a month, and there is a 10% bonus when
-  you transfer 50,000 or more Ultimate Rewards points to Aeroplan. If you do
-  not fly Air Canada or plan to use Aeroplan awards, the 1x base rate leaves
-  little reason to hold it.
+  The Aeroplan card is unusually good for a $95 airline card because its bonus
+  categories are not airline-specific: 3x points on dining and on groceries,
+  which most people spend on every week, alongside 3x on Air Canada purchases.
+  New cardmembers get two years of Aeroplan 25K Elite Status, a free first
+  checked bag for the cardmember and up to eight companions on Air Canada, a
+  Global Entry, TSA PreCheck, or NEXUS credit, and no foreign transaction
+  fees. A monthly spend bonus adds 500 points per $2,000 spent, capped at
+  1,500 points a month. Be aware the signup bonus was cut from 75,000 to
+  60,000 points in June, so the current 60,000 after $3,000 in 3 months is
+  below where it recently sat. The card really pays off only if Aeroplan
+  redemptions fit your travel, since everything outside those categories earns
+  a flat 1x.
 

--- a/data/cards/chase-freedom-flex.yaml
+++ b/data/cards/chase-freedom-flex.yaml
@@ -61,19 +61,17 @@ apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/flex
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  Freedom Flex is the most complete no-annual-fee cash back card we track, and
-  it sits at number one on our Best Cash Back Credit Cards list. You get 5% on
-  rotating quarterly categories up to $1,500 in spending, currently gas
-  stations, EV charging, public transit, and select live entertainment for Q3
-  2026, plus permanent 3% on dining and drugstores, 5% on travel booked
-  through Chase, and 1% on everything else. The $200 bonus after just $500 in
-  three months is one of the lowest hurdles on the market, and 15 months of 0%
-  intro APR on both purchases and balance transfers gives it a second use as a
-  payoff card. Two real catches: the 5% categories require activation each
-  quarter and stop at that $1,500 cap, dropping to 1% after, and the card
-  charges foreign transaction fees, so it should stay home on international
-  trips. Cell phone protection when you pay your bill with the card and six
-  months of DashPass are useful extras rather than reasons to apply.
+  The Freedom Flex is our #1 pick for cash back, and the reason is how much it
+  stacks into a card with no annual fee: 5% on rotating quarterly categories
+  on up to $1,500 in spend, 5% on travel booked through Chase, 3% on dining,
+  and 3% at drugstores. The Q3 2026 rotation covers gas stations and EV
+  charging, public transit, and select live entertainment. It also carries 15
+  months of 0% intro APR on both purchases and balance transfers, a $200 bonus
+  after just $500 in 3 months, and cell phone protection worth up to $800 per
+  claim. The work is on you: the 5% categories require quarterly activation
+  and drop to 1% past the $1,500 cap, and everything outside the bonus
+  categories earns a flat 1%. There is also a foreign transaction fee, so
+  leave this one home when you travel abroad.
 benefits:
   - name: "Cell Phone Protection"
     value: 1000

--- a/data/cards/chase-freedom-student.yaml
+++ b/data/cards/chase-freedom-student.yaml
@@ -33,17 +33,18 @@ apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/rise
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Freedom Rise is built as a starter card, and its clearest draw is a flat
-  1.5% back on everything with no annual fee, so there is no category tracking
-  to learn. Chase adds 3% on dining for the first 6 months, but that is capped
-  at $6,000 of spend and drops to 1.5% after, making it a welcome-period perk
-  rather than a lasting reason to reach for the card at restaurants. There is
-  also a $25 statement credit for enrolling in automatic payments within three
-  months and staying enrolled 90 days, plus six months of DashPass, both
-  one-time sweeteners. The real gaps are what you would expect at this tier:
-  no signup bonus, no 0% intro APR, and a foreign transaction fee, so keep it
-  out of your wallet abroad. The 2% rate on Lyft rides applies only to Lyft
-  and only through September 30, 2027, so treat 1.5% as the card's true base.
+  The Freedom Rise is a starter card that does the important things right: no
+  annual fee, 1.5% cash back on every purchase, and a $25 statement credit for
+  enrolling in automatic payments within the first three months and staying
+  enrolled 90 days, which nudges you toward the habit that actually builds
+  credit. New cardmembers earn 3% on dining, including takeout and eligible
+  delivery, on the first $6,000 spent in the first 6 months, after which that
+  spending drops to the 1.5% base rate. A limited-time promo adds an extra
+  0.5% on qualifying Lyft rides through September 30, 2027, and six months of
+  DashPass is included if you enroll. What it lacks is a signup bonus and any
+  intro APR window, so at 18.24% to 27.74% there is no cushion for carrying a
+  balance. Use it to establish history at 1.5% on everything, then graduate to
+  a card with real bonus categories.
 benefits:
   - name: "DashPass Complimentary Membership"
     value: 0

--- a/data/cards/chase-freedom-unlimited.yaml
+++ b/data/cards/chase-freedom-unlimited.yaml
@@ -47,18 +47,19 @@ apply_link: https://creditcards.chase.com/cash-back-credit-cards/freedom/unlimit
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Freedom Unlimited earns its keep as a no-annual-fee catch-all: 1.5% on
-  everything, with 3% on dining and drugstores and 5% on travel booked through
-  Chase Travel layered on top. It also carries 15 months of 0% intro APR on
-  both purchases and balance transfers, which is a useful window if you are
-  financing something or moving a balance. Chase recently trimmed the signup
-  bonus from $250 to $200, still reachable at just $500 of spend in three
-  months, so the bar to earn it stays low. Two limits to know: there is a
-  foreign transaction fee, so this is not a card for travel abroad, and the 2%
-  Lyft rate applies only to Lyft rides and only through September 30, 2027. It
-  ranks second on our Best Cash Back list and carries our Best No-Fee badge,
-  which is a fair read of what it is: the default card for spend that does not
-  fit a bonus category.
+  The Freedom Unlimited's appeal is that its floor sits higher than most no
+  annual fee cash back cards: 1.5% on everything, with 3% on dining and
+  drugstores and 5% on travel booked through Chase Travel stacked on top. That
+  mix is why it lands at #2 on our Best Cash Back list and why it still works
+  as a catch-all card sitting next to a category card. The $200 bonus after
+  $500 of spend in three months is small in absolute terms but one of the
+  easier thresholds on the market to clear, and 15 months of 0% intro APR on
+  both purchases and balance transfers gives the card a second use as
+  short-term financing. The catches are worth knowing: it charges a foreign
+  transaction fee, which makes it a poor travel companion despite the portal
+  rate, and the 2% on Lyft rides is a limited-time promo good only at Lyft,
+  not transit generally. Six months of DashPass is a pleasant extra, not a
+  reason to apply.
 benefits:
   - name: "DashPass Complimentary Membership"
     value: 0

--- a/data/cards/chase-freedom.yaml
+++ b/data/cards/chase-freedom.yaml
@@ -49,15 +49,16 @@ rewards:
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The original Freedom is closed to new applications, so this is a card you
-  evaluate only if you already have one. Its structure still holds up for
-  existing cardholders: 5% cash back on quarterly rotating categories up to
-  $1,500 in spending each quarter, dropping to 1% after the cap, with 1% on
-  everything else and no annual fee. The current Q3 2026 rotation covers gas
-  stations and EV charging, public transit, select live entertainment, and
-  donations to United Way. The gaps are age-related: it charges foreign
-  transaction fees, so keep it home when you travel, and it lacks the 3%
-  dining and drugstore rates that the Freedom Flex added. If you want the same
-  rotating structure with those extra categories, Freedom Flex is the direct
-  successor, and Freedom Unlimited is the option if you would rather not
-  activate categories every three months.
+  Chase no longer accepts applications for the original Freedom, so this is a
+  card you keep rather than one you get. If you already hold it, the draw is
+  5% back on rotating quarterly categories on up to $1,500 of spend per
+  quarter, which caps the bonus at $75 a quarter, with no annual fee. The Q3
+  2026 rotation covers gas stations and EV charging, public transit, select
+  live entertainment, and United Way donations, so the value depends entirely
+  on whether your spending happens to line up. Everything outside the
+  categories, and everything past the quarterly cap, earns just 1%, and the
+  card charges a foreign transaction fee, so it was never meant to carry
+  general or overseas spend. If you want the same structure on a card that is
+  still open, the Freedom Flex is the direct successor, and the Freedom
+  Unlimited is the flat 1.5% alternative if you would rather not track
+  categories at all.

--- a/data/cards/chase-ink-business-cash.yaml
+++ b/data/cards/chase-ink-business-cash.yaml
@@ -70,19 +70,18 @@ apply_link: https://creditcards.chase.com/business-credit-cards/ink/cash
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Ink Business Cash pays 5% on office supply stores and on internet,
-  cable, and phone services, which covers the recurring bills most small
-  businesses can't avoid, and it does it with no annual fee. Chase recently
-  raised the signup bonus from $750 to $1,000 for $8,000 of spend in the first
-  four months, and a 12-month 0% intro APR on purchases gives new businesses
-  room to buy equipment before interest starts. The catch is the caps: the 5%
-  categories share a combined $25,000 annual limit and fall to 1% after, and
-  the 2% gas and restaurant rate carries its own $25,000 cap, so heavy
-  spenders will outgrow the bonus rates. Everything outside those categories
-  earns just 1%, which is thin enough that you will want a flat-rate card
-  alongside it. There is also a foreign transaction fee, so keep it home for
-  international purchases, and note the 5% transit rate applies only to Lyft
-  rides through September 30, 2027.
+  The Ink Business Cash pays 5% back at office supply stores and on internet,
+  cable, and phone services, which is an unusually strong rate for a card with
+  no annual fee. The limit is the combined $25,000 annual cap across those
+  categories, after which the rate falls to 1%, and gas stations and
+  restaurants earn 2% under a separate $25,000 ceiling. The signup bonus
+  recently rose from $750 to $1,000 after $8,000 of spend in four months, a
+  large return for a card that costs nothing to hold, and 12 months of 0%
+  intro APR on purchases gives a newer business room to finance early costs.
+  Because everything outside the bonus categories earns 1%, this works best as
+  a specialist alongside a flat-rate card rather than as your only business
+  card. It also carries a foreign transaction fee, so keep international
+  purchases elsewhere.
 benefits:
   - name: "Instacart+ Membership"
     value: 0

--- a/data/cards/chase-ink-business-preferred.yaml
+++ b/data/cards/chase-ink-business-preferred.yaml
@@ -60,18 +60,19 @@ apr:
     min: 17.74
     max: 26.74
 our_take: >
-  The Ink Business Preferred's strength is the breadth of its 3x categories:
-  travel, shipping, internet, cable, phone, and advertising on search engines
-  and social media all earn 3 points per dollar on a combined $150,000 a year,
-  which is a high ceiling for a card charging $95. The 100,000-point signup
-  bonus for $8,000 of spend in three months is large enough to justify the
-  first year on its own, and it currently ranks #8 on our Best Signup Bonuses
-  list. Cell phone protection up to $1,000 per claim when you pay the bill
-  with the card and primary rental coverage on business rentals are genuinely
-  useful, not filler. The tradeoff is the 1x rate on everything outside those
-  categories, so this is a card you pair with a flat-rate earner rather than
-  use for all spend. There is no intro APR, and the 5x Lyft rate applies only
-  to Lyft and only through September 30, 2027.
+  The 100,000 point signup bonus after $8,000 of spend in three months is the
+  main reason to apply, and it is what puts the card at #4 on our Best Signup
+  Bonuses list despite a modest $95 annual fee. The ongoing earn is well
+  matched to how businesses actually spend: 3x on travel, shipping, internet,
+  cable, phone, and advertising on search engines and social media, on up to
+  $150,000 in combined spend each year. The limits are real, though.
+  Everything outside those categories earns 1x, and spend beyond the $150,000
+  cap drops to 1x as well, so a business with heavy general spend will leave
+  points behind. There is no intro APR here, so this is a card for spending
+  rather than carrying a balance against a 17.74% to 26.74% regular rate. No
+  foreign transaction fee, cell phone protection up to $1,000 per claim, and
+  primary rental coverage on business rentals make it easy enough to justify
+  keeping past year one.
 benefits:
   - name: "Cell Phone Protection"
     value: 0

--- a/data/cards/chase-ink-business-premier.yaml
+++ b/data/cards/chase-ink-business-premier.yaml
@@ -64,17 +64,15 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  The Ink Business Premier is the rare business card that pays a strong rate
-  on unbonused spend: 2% on everything, rising to 2.5% on any single
-  transaction of $5,000 or more, which suits businesses whose costs come in
-  large invoices rather than neat categories. The $1,000 signup bonus for
-  $10,000 of spend in three months and 5% back on Chase Travel bookings round
-  out the earn, and there is no foreign transaction fee. The $195 annual fee
-  is the hurdle: at 2%, you need roughly $10,000 of annual spend just to cover
-  it against a no-fee 1% card, so the math only works at real volume, ideally
-  with large transactions hitting the 2.5% tier. Protections are solid,
-  including cell phone coverage up to $1,000 per claim, purchase protection to
-  $10,000 per item, an extra year of extended warranty, and primary rental
-  coverage up to $60,000, plus free employee cards. Note there is no intro APR
-  here, and the 5% transit rate covers Lyft rides only, through September 30,
-  2027.
+  The Ink Business Premier is built for large, lumpy business purchases: a
+  flat 2% back on everything, rising to 2.5% on any single transaction of
+  $5,000 or more, plus 5% on travel booked through Chase Travel. If your
+  business regularly writes five-figure checks to vendors that accept cards,
+  that 2.5% tier is the entire argument, and the $1,000 bonus after $10,000 of
+  spend in three months should be straightforward to hit. The $195 annual fee
+  is the tradeoff, and it only pencils out if enough of your spend clears the
+  $5,000 per transaction line, because below it you can find 2% flat for less.
+  There is no intro APR, so plan to pay in full against a 17.74% to 28.49%
+  regular rate. No foreign transaction fee, $1,000 cell phone protection,
+  primary rental coverage up to $60,000, and free employee cards fill out the
+  rest.

--- a/data/cards/chase-ink-business-unlimited.yaml
+++ b/data/cards/chase-ink-business-unlimited.yaml
@@ -32,18 +32,17 @@ apr:
     min: 16.74
     max: 24.74
 our_take: >
-  The Ink Business Unlimited is a one-rule card: 1.5% on every purchase, no
-  annual fee, no categories to track. Chase recently raised the signup bonus
-  from $750 to $1,000 for $8,000 of spend in the first four months, and the
-  12-month 0% intro APR on purchases makes it a reasonable way to float
-  startup or equipment costs interest-free for a year. Simplicity is also the
-  limitation: 1.5% trails what category cards pay on travel, shipping, or
-  advertising, so this works best as the card that catches spend your other
-  business cards do not reward. The foreign transaction fee rules it out for
-  international purchases, and the 5% transit rate applies only to Lyft rides
-  through September 30, 2027. If you want one no-fee business card and no
-  optimization, this is a defensible pick; if you spend heavily in defined
-  categories, pair it with something that pays more there.
+  The Ink Business Unlimited is the simplest card in Chase's business lineup:
+  1.5% back on every purchase, no categories to track, no annual fee. The
+  signup bonus recently rose from $750 to $1,000 after $8,000 of spend in four
+  months, which is a strong return on a card that costs nothing to carry, and
+  12 months of 0% intro APR on purchases makes it usable for financing early
+  expenses. The tradeoff is that 1.5% is the whole story: with no bonus
+  categories, a business with concentrated spend on shipping, advertising, or
+  office supplies will simply earn more elsewhere. It also charges a foreign
+  transaction fee, which rules it out for purchases abroad. The 5% on Lyft
+  rides is a limited-time promo running through September 2027 and applies at
+  Lyft only, not to transit in general.
 apply_link: https://creditcards.chase.com/business-credit-cards/ink/unlimited
 foreign_transaction_fee: true
 network: "visa"

--- a/data/cards/chase-ritz-carlton.yaml
+++ b/data/cards/chase-ritz-carlton.yaml
@@ -72,17 +72,18 @@ apply_link: https://marriott.chase.com/ritz-carlton
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Ritz-Carlton card is built around its annual free night award, good at
-  redemption levels up to 85,000 points, which on the right stay can more than
-  cover the $450 annual fee by itself. Layer in up to $300 a year in airline
-  statement credits, Marriott Bonvoy Gold Elite status with 15 elite night
-  credits, Priority Pass Select with up to two guests, a $120 Global Entry
-  credit every four years, and up to $100 in property credit on two-night
-  stays at Ritz-Carlton and St. Regis, and the fixed benefits are unusually
-  deep for the price. Earning is decent too: 6 points per dollar at
-  participating Marriott hotels, 3x on dining, airlines, and car rentals, and
-  2x on everything else with no foreign transaction fee. The honest catch is
-  that the value is front-loaded into credits and the free night, so you have
-  to actually use the airline credit and book a high-value redemption each
-  year or the fee stops making sense. There is also no signup bonus attached,
-  which removes the usual first-year cushion other premium cards lean on.
+  The Ritz-Carlton card earns its $450 annual fee through credits rather than
+  through earn rates: up to $300 a year in statement credits on airline
+  purchases such as bag fees and seat upgrades, a $120 Global Entry credit
+  every four years, and up to $100 in property credit for dining, spa, or
+  recreation on stays of two nights or more at Ritz-Carlton and St. Regis
+  hotels. The annual free night award, good for a standard room at redemption
+  levels up to 85,000 points, is the single most valuable piece if you can
+  place it at a property that prices near that ceiling. Automatic Marriott
+  Bonvoy Gold Elite status, 15 elite night credits each calendar year, and
+  Priority Pass Select with up to two guests round out a package aimed at
+  frequent Marriott stays. The earn rates are the weaker half: 6x applies only
+  at participating Marriott hotels, dining, airlines, and car rentals earn 3x,
+  and everything else earns 2x. This is a card for someone genuinely loyal to
+  Marriott who will use the airline credit and the free night every year; if
+  either goes unused, the fee stops making sense.

--- a/data/cards/chase-sapphire-preferred.yaml
+++ b/data/cards/chase-sapphire-preferred.yaml
@@ -98,18 +98,18 @@ apply_link: https://creditcards.chase.com/rewards-credit-cards/sapphire/preferre
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Sapphire Preferred remains the best value in travel cards at its price,
-  and it sits at #1 on our Best Travel list: $95 a year buys 5x on Chase
-  Travel bookings, 3x on dining, gas and EV charging, and streaming, 2x on all
-  other travel, and no foreign transaction fee. The $100 annual hotel credit
-  for stays booked through Chase Travel effectively cuts the fee to nearly
-  nothing if you use it, and a $120 Global Entry credit every four years, a
-  year of Apple TV, and DashPass fill in around it. The current 75,000-point
-  signup bonus for $5,000 of spend in three months is worth noting for timing:
-  it climbed to 100,000 points in June and came back down on August 1, so this
-  is the standard offer rather than the peak. Read the 3x categories
-  precisely, since groceries only counts online grocery purchases and excludes
-  Target, Walmart, and wholesale clubs, and the 3x vacation rental rate
-  applies only to the named brands like Airbnb and Vrbo. Everything outside a
-  bonus category earns 1x, so this is a card for travel and dining, not for
-  all your spend.
+  The Sapphire Preferred remains the default first travel card, and it
+  currently tops both our Best Travel and Best Signup Bonuses lists on the
+  strength of 75,000 points after $5,000 of spend in three months against a
+  $95 annual fee. Be aware the offer has moved recently: it climbed to 100,000
+  points in June and came back down to 75,000 on August 1, so today's number
+  is the lower of the two. Earning is broad rather than deep, with 5x on Chase
+  Travel bookings, 3x on dining, gas and EV charging, streaming, and online
+  groceries, 2x on all other travel, and 1x on everything else. The $100
+  annual hotel credit for stays booked through Chase Travel offsets most of
+  the fee if you book even one hotel that way, and the $120 Global Entry
+  credit plus no foreign transaction fees make it a sensible card to actually
+  travel with. Two limits to read closely: the 3x grocery rate covers online
+  orders only and excludes Target, Walmart, and wholesale clubs, and the 3x
+  vacation rental rate applies only to bookings made directly with named
+  brands such as Airbnb and Vrbo.

--- a/data/cards/chase-sapphire-reserve-business.yaml
+++ b/data/cards/chase-sapphire-reserve-business.yaml
@@ -145,18 +145,18 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  The business version of the Sapphire Reserve pairs premium travel benefits
-  with credits aimed at actual operating costs: up to $400 a year for
-  ZipRecruiter, $200 for Google Workspace, $250 on select Chase Travel hotel
-  bookings through 2026, $300 in automatic travel credit, and up to $500
-  through The Edit. Earning is travel-focused at 8x on Chase Travel and 4x on
-  hotels and flights booked directly, with Priority Pass and Sapphire Lounge
-  access, primary rental coverage, cell phone protection up to $1,000 per
-  claim, and free employee cards. The current elevated offer is 200,000 points
-  for $30,000 of spend in six months, well above the 150,000-point standard
-  offer, but that spend requirement is steep and only realistic for a business
-  with real volume. The $795 annual fee demands the same discipline as the
-  personal card: the credits are capped, merchant-specific, and several expire
-  at the end of 2027, so value them at what you would have spent anyway.
-  Everything outside the bonus categories earns 1x, and the $120,000 spend
-  unlocks are a tier most cardholders will never reach.
+  The business version of the Reserve leads with an elevated 200,000 point
+  bonus after $30,000 of spend in six months, up from the standard 150,000,
+  and that offer is the strongest reason to look at it right now. Against the
+  $795 annual fee, the credits are pointed squarely at operating costs: $300
+  in annual travel credit, up to $500 a year through The Edit by Chase Travel,
+  up to $400 a year in ZipRecruiter credits, and up to $200 a year on Google
+  Workspace, alongside Priority Pass and Chase Sapphire Lounge access. Earning
+  is top-heavy at 8x on Chase Travel bookings and 4x on hotels and flights
+  booked directly with the provider, but everything else earns 1x, so this is
+  not where general business spend belongs. Go in clear-eyed about the
+  mechanics: $30,000 in six months is a steep requirement, several credits
+  arrive in semi-annual halves you have to remember to use, and a number of
+  them carry end dates in 2027. Used deliberately by a business that books
+  travel through Chase, it clears the fee comfortably; used passively, it will
+  not.

--- a/data/cards/chase-sapphire-reserve.yaml
+++ b/data/cards/chase-sapphire-reserve.yaml
@@ -149,17 +149,18 @@ apply_link: https://creditcards.chase.com/rewards-credit-cards/sapphire/reserve
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Sapphire Reserve's case is the credit stack, not the earn rates: $300 in
-  automatic travel credit, up to $500 a year through The Edit, up to $300 in
-  OpenTable dining credits, $300 in StubHub credits, $300 in DoorDash promos,
-  $120 for Lyft, and $120 for Peloton, plus Priority Pass and Sapphire Lounge
-  access. Add 8x on Chase Travel bookings and 4x on hotels and flights booked
-  directly, and a heavy traveler who uses the credits can clear the $795
-  annual fee. That fee is also the whole risk: most of those credits are
-  capped monthly or semi-annually and tied to specific merchants, so anything
-  you would not have bought anyway is not real value, and the card earns just
-  1x outside its bonus categories. The signup bonus is 100,000 points for
-  $6,000 of spend in three months, down from 150,000 in June, so the current
-  offer is well off its recent high. It ranks #2 on our Best Travel list,
-  which reflects a card that rewards deliberate use and punishes passive
-  ownership.
+  The Reserve's case is that its credits can cover the $795 annual fee before
+  you earn a single point: $300 in automatic travel credit, up to $500 a year
+  through The Edit by Chase Travel, up to $300 in dining credits at Sapphire
+  Exclusive Tables on OpenTable, and up to $300 in StubHub credits, plus
+  Priority Pass and Chase Sapphire Lounge access. Earning is concentrated at
+  the top with 8x on Chase Travel, 4x on hotels and flights booked directly,
+  3x on dining, and 1x on everything else, so the card rewards booking through
+  Chase far more than it rewards daily spend. The signup bonus was cut from
+  150,000 to 100,000 points in June and now takes $6,000 of spend in three
+  months, still enough to hold #3 on our Best Signup Bonuses list and #2 among
+  travel cards. The real question is whether you will use the credits the way
+  they are structured, since most arrive in semi-annual halves tied to
+  specific merchants and several stop at the end of 2027. If you book hotels
+  through Chase and eat out on the dining credit, you come out ahead; if you
+  want one simple card at a simple price, this is not it.

--- a/data/cards/chase-slate-edge.yaml
+++ b/data/cards/chase-slate-edge.yaml
@@ -15,16 +15,17 @@ apply_link: https://creditcards.chase.com/credit-building-credit-cards/edge
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Slate Edge's appeal is its price: no annual fee on a card built for
-  carrying a balance, which is enough to land it at #6 on our list of the best
-  0% APR cards. The problem is what comes after the intro window. There is no
-  rewards program here at all, no cash back and no points, and the ongoing APR
-  is a flat 28.99% with no low end to fall into if your credit is strong. It
-  also charges foreign transaction fees, so it should stay home on any trip
-  abroad. The lone perk is six months of complimentary DashPass, with DashPass
-  members getting up to $10 off quarterly on non-restaurant DoorDash orders
-  through the end of 2027, a nice touch but not a reason to keep the account
-  open.
+  The Slate Edge charges no annual fee, but that is close to the whole of its
+  appeal: it earns no rewards on any purchase, and its terms here list a flat
+  28.99% APR with no intro period attached. That makes it hard to justify as a
+  spending card, since any no annual fee cash back card will pay you something
+  for purchases this one does not. Six months of complimentary DashPass, plus
+  up to $10 off quarterly on non-restaurant DoorDash orders through 2027, is
+  the only ongoing perk. If you are considering it specifically for
+  promotional financing, confirm the current offer on Chase's application page
+  first, because no intro rate appears in the terms shown here. Otherwise
+  there is little reason to pick it over a rewards card that costs the same
+  nothing to hold.
 benefits:
   - name: "Complimentary DashPass"
     value: 0

--- a/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
+++ b/data/cards/citi-aadvantage-executive-world-elite-masterc.yaml
@@ -99,20 +99,18 @@ apply_link: https://www.citi.com/credit-cards/citi-aadvantage-executive-world-le
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  Full Admirals Club membership for you and your authorized users is still the
-  entire argument for the Executive, and if you fly American often enough to
-  use those lounges it is the cleanest way to buy them. The August 2026
-  refresh renamed the card from World Elite to World Legend and pushed the fee
-  from $595 to $695, adding up to $500 a year in American Airlines Vacations
-  credits, up to $100 back on inflight and Admirals Club purchases, and Omni
-  Hotels Champion Status. Lyft credits rose to $180 a year at $15 a month
-  after three eligible rides, and the Loyalty Points bonuses doubled to 40,000
-  with new milestones at 165,000 and 240,000. The Grubhub credit is gone for
-  new cardmembers. The current limited time offer is 125,000 miles after
-  $15,000 in five months, a much larger bonus behind a much larger spend
-  requirement. Earning is still narrow: 12x on hotels and cars booked through
-  American's portals and 4x on American Airlines purchases, rising to 5x after
-  $150,000 of spend in a calendar year, with everything else at a flat 1x. The
-  Vacations credit only pays out on packaged bookings, so treat it as
-  conditional and buy this card for the lounge access.
+  Full Admirals Club membership is the reason to carry this one: lounge access
+  for you and your authorized users, which is the hardest AAdvantage perk to
+  replicate anywhere else. Citi raised the annual fee from $595 to $695 in
+  late August and paired it with a much larger signup bonus, now 125,000 miles
+  after $15,000 of spending in five months. The earn rates are narrow, though:
+  12x on eligible AAdvantage Hotels and Cars bookings, 4x on American Airlines
+  purchases, and only 1x on everything else, so this is not a card for daily
+  spend. The fee is meant to be offset by credits that arrive in pieces,
+  including up to $500 a year on American Airlines Vacations packages split
+  across two halves of the year, $180 in Lyft credits at $15 a month after
+  three rides, $120 on prepaid Avis or Budget rentals, and $100 on inflight
+  and Admirals Club purchases. If you fly American often enough to use the
+  lounge and can clear a $15,000 spending requirement, the math works; if not,
+  $695 is hard to justify.
 

--- a/data/cards/citi-aadvantage-globe.yaml
+++ b/data/cards/citi-aadvantage-globe.yaml
@@ -96,19 +96,17 @@ apply_link: https://www.citi.com/credit-cards/citi-aadvantage-globe-mastercard
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Globe stacks an unusual set of credits behind its $350 fee: up to $240 a
-  year on eligible Turo trips, $100 on inflight purchases, and a $100 splurge
-  credit spread across up to two of 1stDibs, AAdvantage Hotels, Future
-  Personal Training, and Live Nation, plus four Admirals Club Globe passes and
-  a domestic companion certificate starting at your second-year renewal.
-  Earning is more balanced than most co-brands: 6x through
-  aadvantagehotels.com, 3x on American Airlines purchases, 2x on dining and on
-  rides and rails, and 1x on everything else, with no foreign transaction fee.
-  Timing matters on the bonus, which climbed to 90,000 miles in May and fell
-  back on July 1 to 60,000 after $4,000 in three months, so this is not the
-  peak offer. The catch is that nearly every credit is capped,
-  enrollment-gated, or tied to specific vendors, so you have to actually rent
-  through Turo, buy things onboard, and shop those four splurge brands to
-  clear the fee. If you fly American a few times a year, the 5,000 Loyalty
-  Points after every four qualifying flights, up to 15,000 a year, is the
-  quieter reason to hold it.
+  The Globe sits between American's entry and top-tier cards: for $350 a year
+  you get four Admirals Club Globe passes rather than full membership, a
+  companion certificate starting at your second renewal, a free first checked
+  bag, and preferred boarding. Earning is better than on the cheaper
+  AAdvantage cards, with 3x on American Airlines purchases and 2x on dining
+  and on rides and rails, though everything else still sits at 1x. The signup
+  bonus is worth timing: it climbed to 90,000 miles in May before falling back
+  on July 1 to 60,000 after $4,000 in three months, so you are looking at the
+  low end of its recent range. Getting your money's worth means using credits
+  that require enrollment and specific vendors, notably $240 a year on Turo
+  rentals and $100 split across a short brand list that includes 1stDibs and
+  Live Nation. Add the $100 inflight credit and 5,000 Loyalty Points after
+  every four qualifying flights, and this fits a frequent American flyer who
+  does not need lounge access on every trip.

--- a/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
+++ b/data/cards/citi-aadvantage-platinum-select-world-elite-m.yaml
@@ -62,15 +62,13 @@ apply_link: https://www.citi.com/credit-cards/citi-aadvantage-platinum-select-wo
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  For $99 waived the first 12 months, the Platinum Select covers the two
-  things most American Airlines flyers actually want: a free first checked bag
-  on domestic itineraries and preferred boarding, which can pay the fee back
-  on a single round trip. The signup bonus is back at its high mark of 80,000
-  miles after $3,500 in four months, after dipping to 50,000 in late April and
-  recovering in June. That combination is why it carries our Best Overall
-  badge among airline cards. Earning is simple and shallow, though: 2x on
-  American Airlines purchases, dining, and gas, and 1x on everything else, so
-  this is a benefits card first and a rewards card a distant second. There is
-  no lounge access and no statement credits, with a 25% discount on inflight
-  food and drink as the only other perk, and no foreign transaction fee makes
-  it fine to carry abroad.
+  A free first checked bag on domestic American itineraries is the whole case
+  here: at $99 a year, waived for the first year, the card pays for itself for
+  anyone checking luggage on a couple of round trips. That concrete, low-cost
+  benefit is why it currently tops our list of the best airline cards. Timing
+  is less kind at the moment, since the signup bonus fell from 80,000 miles
+  back to 50,000 after $2,500 in three months in late August, putting it at
+  the bottom of its recent range. Earning is modest, with 2x on American
+  Airlines purchases, dining, and gas, and 1x on everything else, so hold this
+  for the bag and boarding perks rather than for spending. Preferred boarding
+  and 25% off inflight food and drinks round it out.

--- a/data/cards/citi-custom-cash.yaml
+++ b/data/cards/citi-custom-cash.yaml
@@ -55,16 +55,16 @@ apr:
     max: 27.49
 apply_link: https://www.citi.com/credit-cards/citi-custom-cash-credit-card
 our_take: >
-  Citi stopped accepting new applications for the Custom Cash on May 28, 2026,
-  so this is now a card you keep rather than one you can get. For existing
-  holders it remains one of the easiest 5% cards to use: it automatically pays
-  5% on your top eligible spending category each billing cycle, drawn from a
-  list that includes dining, groceries, gas, transit, travel, streaming,
-  drugstores, home improvement, and entertainment, with no annual fee and
-  nothing to activate. The cap is the real limit, 5% only on the first $500
-  each month and 1% after that, the same rate everything else earns. If you
-  were planning to apply, the closest replacements are the U.S. Bank Cash+
-  with two chosen 5% categories on the first $2,000 a quarter, the Chase
-  Freedom Flex with rotating 5% categories, or Citi's own Double Cash at a
-  flat 2%. It still ranks third on our best cash back list, but that ranking
-  is academic now for anyone who does not already hold it.
+  Citi stopped accepting new applications for the Custom Cash in May 2026, so
+  this is now a card you can keep but not open. If you already have it, the 5%
+  back on your top eligible spending category each billing cycle is still one
+  of the simplest ways to earn a high rate without tracking a rotating
+  calendar, covering dining, gas, groceries, transit, travel, streaming,
+  drugstores, home improvement, and entertainment. The cap is the real limit:
+  5% applies only to the first $500 in that category each month and drops to
+  1% after, and everything outside your top category earns 1%, all with no
+  annual fee. Anyone shopping for a replacement should look at the U.S. Bank
+  Cash+ for two chosen 5% categories each quarter, the Chase Freedom Flex for
+  rotating 5% categories, or Citi's own Double Cash for a flat 2%. The 15
+  month 0% intro APR on purchases and balance transfers is no longer available
+  to new applicants.

--- a/data/cards/citi-diamond-preferred.yaml
+++ b/data/cards/citi-diamond-preferred.yaml
@@ -21,12 +21,13 @@ apply_link: https://www.citi.com/credit-cards/citi-diamond-preferred-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Diamond Preferred is a debt payoff tool and little else: 21 months of 0%
-  intro APR on balance transfers, one of the longer windows on the market,
-  plus 12 months at 0% on purchases and no annual fee. That makes it a
-  straightforward pick if you have a balance to move and a realistic plan to
-  clear it inside those 21 months, and it is why the card sits at #5 on our
-  best 0% APR list. Be clear-eyed about the rest. It earns no rewards at all,
-  so there is no cash back or points to keep it relevant once the intro period
-  ends, and the go-to rate then runs 16.49% to 27.24%. It also charges foreign
-  transaction fees, so leave it home when you travel.
+  The Diamond Preferred is built for one job: 21 months of 0% intro APR on
+  balance transfers, one of the longer runways on the market, with no annual
+  fee. If you are moving existing debt and want as much time as possible to
+  pay it down, that window is the reason to apply. Purchases get a shorter 12
+  months at 0%, so treat this as a transfer card first and a
+  purchase-financing card second. Be clear about what it does not do: it earns
+  no rewards of any kind, and it charges foreign transaction fees, so it
+  should stay home when you travel. Open it, finish your payoff plan before
+  the rate resets into the 16.49% to 27.24% range, and expect little reason to
+  keep using it after that.

--- a/data/cards/citi-double-cash.yaml
+++ b/data/cards/citi-double-cash.yaml
@@ -33,15 +33,15 @@ apply_link: https://www.citi.com/credit-cards/citi-double-cash-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Double Cash's flat 2% is still the simplest way to beat a 1% card on
-  every purchase, paid as 1% when you buy and 1% when you pay it off, with no
-  annual fee and no categories to track. Hotels, car rentals, and attractions
-  booked through the Citi Travel portal earn 5%, and there is a $200 bonus
-  after $1,500 of spend in the first six months. It also carries 18 months of
-  0% intro APR on balance transfers, which is unusual for a flat-rate card and
-  gives you a payoff runway and a permanent earn rate in one account. Two
-  caveats: the second 1% only lands as you pay the balance down, so carrying
-  debt on it works against the whole premise, and it charges foreign
-  transaction fees, which makes it a domestic card. At #4 on our best cash
-  back list, it is best used as the default card behind whatever category
-  cards you already carry.
+  The Double Cash is the plainest version of a good cash back card: 2% on
+  everything, paid as 1% when you buy and 1% when you pay, with no annual fee
+  and no categories to track. That flat rate makes it a reasonable default for
+  spending that does not land in a bonus category on another card, and it
+  currently sits third on our best cash back list. There is a $200 bonus after
+  $1,500 of spending in six months, plus 18 months of 0% intro APR on balance
+  transfers if you are carrying a balance. Two caveats: the 5% rate applies
+  only to hotels, car rentals, and attractions booked through the Citi Travel
+  portal rather than to travel generally, and the card charges foreign
+  transaction fees, which makes it a poor choice abroad. The second half of
+  the 2% only lands when you pay the bill, a fine incentive but worth
+  understanding if you expect to earn everything at the register.

--- a/data/cards/citi-secured-mastercard.yaml
+++ b/data/cards/citi-secured-mastercard.yaml
@@ -15,14 +15,13 @@ apply_link: https://www.citi.com/credit-cards/citi-secured-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Citi Secured Mastercard exists for one job: building or rebuilding
-  credit with a major issuer at no annual fee, and it ranks fourth on our list
-  of the best secured cards for exactly that reason. Because it is secured,
-  your deposit sets the line, so approval leans on your ability to fund the
-  account rather than an established score. Be honest with yourself about the
-  tradeoffs before applying: there are no rewards of any kind, the regular APR
-  is a flat 25.99%, and there is a foreign transaction fee, so this is not a
-  card to carry a balance on or take abroad. Use it for small monthly charges
-  you pay off in full, let the on-time history accumulate, and plan to
-  graduate to a rewards card once your profile supports one. Treated that way
-  it does its job well, but it is a stepping stone, not a keeper.
+  This is a credit-building card first and last: it carries no annual fee, so
+  the only money you commit is the deposit backing your credit line. Zero
+  yearly cost plus a major issuer reporting your payment history is why it
+  lands fourth on our list of the best secured cards. What it does not do is
+  earn: there are no rewards, no bonus categories, and no signup bonus, so
+  there is no reason to put spending on it beyond building a record. The APR
+  is a flat 25.99%, high enough that carrying a balance would undo the point
+  of the card, and it charges foreign transaction fees. Use it for a few small
+  recurring charges you pay in full each month, then graduate to a rewards
+  card once your credit supports one.

--- a/data/cards/citi-simplicity-card.yaml
+++ b/data/cards/citi-simplicity-card.yaml
@@ -21,14 +21,13 @@ apply_link: https://www.citi.com/credit-cards/citi-simplicity-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  Simplicity is a debt payoff tool first and last: 18 months of 0% intro APR
-  on both purchases and balance transfers with no annual fee, which is why it
-  sits at number four on our list of the best 0% APR cards. That runway is
-  long enough to clear a meaningful balance if you divide what you owe by 18
-  and actually hold to the payment schedule. The tradeoff is that the card
-  earns nothing at all, so once the intro window closes there is no cash back
-  or points to justify keeping it in rotation, and the go-to APR of 17.49% to
-  28.24% is a real penalty if the balance is still there. It also charges a
-  foreign transaction fee, so leave it home when you travel. Open it with a
-  payoff date circled on the calendar, and treat anything after that date as a
-  spare line of credit rather than a spending card.
+  The Simplicity is a debt-payoff tool: 18 months of 0% intro APR on both
+  purchases and balance transfers, with no annual fee. Getting the same 18
+  month window on purchases as on transfers is what separates it from Citi's
+  own Diamond Preferred, which runs longer on transfers but only 12 months on
+  purchases, so choose this one if you also need to finance new spending.
+  After the intro period the rate resets to somewhere between 17.49% and
+  28.24%, and that is the deadline your payoff plan has to beat. The tradeoff
+  is that the card earns nothing at all: no cash back, no points, no signup
+  bonus, and it charges foreign transaction fees. Open it for the 0% runway
+  and expect to stop reaching for it once that window closes.

--- a/data/cards/citi-strata-elite.yaml
+++ b/data/cards/citi-strata-elite.yaml
@@ -89,19 +89,17 @@ apply_link: https://www.citi.com/credit-cards/citi-strata-elite-credit-card
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The case for the Strata Elite is the credit stack against its $595 annual
-  fee: up to $300 off a hotel stay of two or more nights booked through Citi
-  Travel, $200 a year split across two halves for Blacklane chauffeur service,
-  a $200 splurge credit across a short brand list that includes American
-  Airlines and Best Buy, up to $120 for Global Entry or TSA PreCheck every
-  four years, unlimited Priority Pass Select access, and four Admirals Club
-  passes. Use most of those and the fee stops being the deciding factor.
-  Earning is where you need to be realistic: the headline 12x on hotels, car
-  rentals, and attractions and 6x on air travel apply only to bookings made
-  through Citi Travel, and outside of 3x dining, which rises to 6x on Friday
-  and Saturday nights between 6PM and 6AM ET, everything else earns 1.5x. The
-  75,000 point bonus after $6,000 in three months and the absence of foreign
-  transaction fees round it out, and it currently sits eighth on our best
-  travel cards list. It suits a Citi Travel booker who will actually schedule
-  the Blacklane and hotel credits, and it is a poor fit for anyone who books
-  direct.
+  The Strata Elite earns 1.5x on everything, which is unusually strong for a
+  premium card whose peers fall to 1x outside bonus categories, and it stacks
+  12x on hotels, car rentals, and attractions booked through Citi Travel on
+  top of that. Dining pays 3x, rising to 6x on Citi Nights, Friday and
+  Saturday between 6PM and 6AM Eastern. The $595 annual fee only works if you
+  use the credits, and they are specific: up to $300 off one hotel stay of two
+  or more nights booked through Citi Travel, $200 a year split between two of
+  five brands including American Airlines and Best Buy, $200 with Blacklane
+  chauffeur service in two $100 halves, and $120 toward Global Entry or TSA
+  PreCheck every four years. Lounge access is unlimited Priority Pass Select
+  plus four Admirals Club passes a year, which is solid but not the same as a
+  full membership. With a 75,000 point bonus after $6,000 in three months and
+  no foreign transaction fees, it fits someone who books travel through Citi
+  and will genuinely redeem the hotel and Blacklane credits.

--- a/data/cards/citi-strata-premier.yaml
+++ b/data/cards/citi-strata-premier.yaml
@@ -53,17 +53,16 @@ apply_link: https://www.citi.com/credit-cards/citi-strata-premier-credit-card
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Strata Premier is one of the better $95 travel cards on rate breadth
-  alone: 3x points on airlines, hotels booked directly, dining, groceries, and
-  gas including EV charging, which is a rare combination of travel and
-  everyday categories on a single card. A 60,000 point bonus after $4,000 in
-  three months, no foreign transaction fees, and a $100 credit on a single
-  hotel stay of $500 or more booked through Citi Travel effectively cover the
-  fee in year one and most years after, if you take the stay. The 10x rate is
-  portal only, applying to hotels, car rentals, and attractions booked through
-  Citi Travel, and unbonused spend drops to a plain 1x, so this is a card you
-  pair with a flat-rate earner rather than use for everything. It ranks third
-  on our best travel cards list and fifth for dining and groceries, which is a
-  fair reflection of how much ground it covers. For most people it is the more
-  sensible Citi travel card of the two.
+  The Strata Premier's appeal is the breadth of its 3x categories: air travel,
+  hotels booked directly, dining, groceries, and gas including EV charging all
+  earn the same elevated rate, which is rare on a $95 card and why it carries
+  our Best for Dining and Groceries badge. One card can cover most of a
+  household's regular spending with no categories to track or activate.
+  Bookings through Citi Travel earn 10x on hotels, car rentals, and
+  attractions, and a $100 credit each calendar year applies to a single hotel
+  stay of $500 or more booked the same way, which roughly offsets the annual
+  fee if you use it. The signup bonus is 60,000 points after $4,000 in three
+  months, and there are no foreign transaction fees. The weak spot is
+  everything outside those categories, which earns just 1x, so pair it with a
+  flat-rate card for the rest.
 

--- a/data/cards/citi-strata.yaml
+++ b/data/cards/citi-strata.yaml
@@ -59,16 +59,15 @@ apply_link: https://www.citi.com/credit-cards/citi-strata-credit-card
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Strata packs an unusual amount of category coverage into a card with no
-  annual fee: 3x points on groceries, gas including EV charging, and transit,
-  plus 2x on dining and a self-select 3x category you can move once a quarter
-  among streaming, fitness clubs, live entertainment, salons, or pet supply
-  stores. Add a 20,000 point bonus after $1,000 of spend in the first three
-  months, a low bar, and 15 months of 0% intro APR on purchases and balance
-  transfers, and it works as both a starter rewards card and a short-term
-  financing tool. The 5x rate is narrower than it looks: it applies only to
-  hotels, car rentals, and attractions booked through Citi Travel, not to
-  travel generally, and everything outside a bonus category earns a flat 1x.
-  There is also a foreign transaction fee, which is an odd omission on a card
-  filed under travel. Think of it as a well-rounded domestic everyday card
-  rather than a passport companion.
+  The Strata's appeal is breadth for no annual fee: 3x points on groceries,
+  gas including EV charging, and transit, 2x on dining, plus 3x on one
+  self-select category you can change each calendar quarter from a short list
+  that includes streaming, fitness clubs, live entertainment, and pet supply
+  stores. The 5x rate is narrower than it looks, applying only to hotels, car
+  rentals, and attractions booked through Citi Travel. A 20,000-point bonus
+  after $1,000 in the first 3 months is easy to clear, and 15 months of 0%
+  intro APR on both purchases and balance transfers gives it a second use as a
+  payoff card. The real catch for a card filed under travel is the foreign
+  transaction fee, which makes it a poor choice abroad. Think of it as a
+  strong domestic everyday earner with a travel-branded portal bonus attached,
+  not a card to pack for an international trip.

--- a/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
+++ b/data/cards/citibusiness-aadvantage-platinum-select-maste.yaml
@@ -18,20 +18,19 @@ foreign_transaction_fee: false
 network: "mastercard"
 reward_type: "miles"
 our_take: >
-  This is a fleet-and-phone-bill business card with American Airlines perks
-  attached: 2x miles on car rentals, gas, and telecom, cable, and satellite
-  providers, plus 2x on eligible American Airlines purchases, with everything
-  else at 1x. The travel benefits are the real draw, since a free first
-  checked bag and Group 5 boarding extend to the cardmember and up to four
-  companions on the same reservation, which pays for the $99 annual fee on a
-  single family trip. That fee is waived for the first 12 months, and there
-  are no foreign transaction fees. On the bonus, be aware of the timing: it
-  rose from 65,000 to 75,000 miles at the end of April and fell back to 65,000
-  in early May, so the current offer is 65,000 miles after $4,000 in purchases
-  in four months and the higher version has surfaced before. The companion
-  certificate requires $30,000 in purchases each cardmembership year, which is
-  a high bar for a small business, so treat it as a bonus rather than part of
-  the math.
+  This is a fleet-and-office card for a business that flies American: 2x miles
+  on eligible American Airlines purchases, car rentals, gas, and telecom,
+  cable, and satellite providers, with everything else at 1x. The travel perks
+  are the reason to keep it past year one, with a free first checked bag on
+  domestic American itineraries for you and up to 4 companions on the same
+  reservation, Group 5 boarding for the same group, and 25% back on in-flight
+  food, beverages, and Wi-Fi. The signup bonus was trimmed from 75,000 to
+  65,000 miles in May, still a solid haul for $4,000 of spend in 4 months. The
+  $99 annual fee is waived for the first 12 months, and there are no foreign
+  transaction fees. Be realistic about the companion certificate: it takes
+  $30,000 in purchases each cardmembership year and still carries a $99
+  ticketing fee plus taxes, so most cardholders should value this card on the
+  bag fees and boarding alone.
 tags:
   - travel
   - airline

--- a/data/cards/coinbase-one.yaml
+++ b/data/cards/coinbase-one.yaml
@@ -24,16 +24,16 @@ apr:
     max: 29.49
 foreign_transaction_fee: false
 our_take: >
-  The Coinbase One Card is built for people already deep in the Coinbase
-  ecosystem: it pays 2% back in bitcoin on everything with no annual fee, and
-  that rate scales to 2.5%, 3%, or 4% depending on the assets you hold on
-  Coinbase. Read the fine print on the upper tiers, though, because anything
-  above 2% is capped at $10,000 of eligible purchases per month and drops to
-  2% after that, and the whole rewards structure requires a paid Coinbase One
-  membership you have to factor into the return. Travel booked through the
-  card's own travel portal earns 5% in bitcoin and sits outside the tier cap,
-  which is the one genuinely strong rate here. There are no foreign
-  transaction fees and no signup bonus, and the regular APR runs 19.49% to
-  29.49%, so this only works as a pay-in-full card. If you would rather not
-  hold a balance in bitcoin or do not keep meaningful assets at Coinbase, a
-  plain 2% cash back card gets you the same base rate without the conditions.
+  The pitch is a flat 2% back in bitcoin on everything with no annual fee,
+  scaling to 2.5%, 3%, or 4% depending on how much you hold on Coinbase. That
+  tiering is where the fine print lives: anything above the 2% base is capped
+  at $10,000 of eligible purchases per month and drops back to 2% after, and
+  the whole card requires an active Coinbase One membership, so the true
+  no-strings rate is 2%. Booking flights, hotels, and cars through the
+  Coinbase One Card travel portal earns 5% and sits outside the tier cap,
+  which is the card's most interesting rate. There is no signup bonus and no
+  intro APR, so the value is entirely in the ongoing earn, and the 19.49% to
+  29.49% regular APR means it only works if you pay in full. It suits someone
+  already paying for Coinbase One and comfortable being paid in bitcoin; for
+  anyone else, a plain 2% cash back card does the same job without the
+  membership.

--- a/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-business-card-by-citi.yaml
@@ -43,14 +43,14 @@ apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-business-card
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The gas rate is why this card exists: 4% back on eligible gas and EV
-  charging worldwide, and 5% at Costco gas stations, which is among the best
-  fuel earning available to a business with no annual fee. Watch the ceiling,
-  because the 4% applies to the first $7,000 of combined gas and charging each
-  year and everything past that drops to 1%, so a heavy fleet will exhaust it.
-  Beyond fuel it earns 3% on dining and on travel including Costco Travel, and
-  2% on Costco and Costco.com purchases only, a rate that does not extend to
-  Sam's Club, BJ's, or any other warehouse club. Everything else earns 1%, so
-  this is not the card for general business spend. No foreign transaction fees
-  and a $0 annual fee make it easy to keep alongside a stronger everyday
-  earner.
+  For a business that burns fuel, this is the draw: 4% back on eligible gas
+  and EV charging worldwide on the first $7,000 each year, which is $280 of
+  rewards before the rate drops to 1%, and 5% at Costco gas stations. Dining
+  and travel, including Costco Travel, both earn 3%, so a card with no annual
+  fee covers three of the most common business expense lines at a strong rate.
+  Read the 2% warehouse rate carefully: it applies only to Costco and
+  Costco.com, not to Sam's Club, BJ's, or other warehouse clubs. There is no
+  signup bonus and no intro APR offer here, so the value builds slowly through
+  everyday spend rather than arriving up front. With no foreign transaction
+  fee it also travels well, but the 1% base rate means you should pair it with
+  a better general-spend card for everything outside the bonus categories.

--- a/data/cards/costco-anywhere-visa-card-by-citi.yaml
+++ b/data/cards/costco-anywhere-visa-card-by-citi.yaml
@@ -42,15 +42,15 @@ apply_link: https://www.citi.com/credit-cards/costco-anywhere-visa-card
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  This is a gas card with a Costco logo on it, and the fuel rate is genuinely
-  strong: 4% back on eligible gas and EV charging worldwide, or 5% at Costco's
-  own stations, with no annual fee. The limit matters more than most people
-  realize, since the 4% covers only the first $7,000 in combined gas and
-  charging per year before falling to 1%, which a long commute can burn
-  through by autumn. The other rates are reasonable rather than exceptional:
-  3% on dining and on travel including Costco Travel, and 2% inside Costco and
-  on Costco.com, which does not carry over to Sam's Club, BJ's, or other
-  warehouse clubs. Base spend earns a flat 1%, so you will want a better
-  catch-all card for everything outside those categories. With no foreign
-  transaction fee and nothing to pay for the privilege, it is an easy
-  supporting card if you fill up often and shop at Costco.
+  The gas rate carries this card: 4% on eligible gas and EV charging worldwide
+  on the first $7,000 per year, then 1%, plus 5% at Costco gas stations, all
+  with no annual fee. Restaurants and travel, including Costco Travel, earn
+  3%, which makes it a reasonable one-card answer for a household whose
+  spending skews toward driving, eating out, and the occasional trip. Two
+  limits matter. The 2% warehouse rate is good only at Costco and Costco.com,
+  not at Sam's Club, BJ's, or other clubs, and everything outside the bonus
+  categories earns just 1%, so groceries bought anywhere but Costco are poorly
+  served. There is no signup bonus and no intro APR window, so nothing
+  sweetens the first year; with no foreign transaction fee and a 18.74% to
+  26.74% regular APR, treat it as a long-term category card you pay off in
+  full.

--- a/data/cards/delta-skymiles-blue-american-express-card.yaml
+++ b/data/cards/delta-skymiles-blue-american-express-card.yaml
@@ -7,19 +7,18 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Blue is the entry point to the Delta portfolio and earns its spot as our
-  best no-fee airline pick at number 19: it costs nothing annually and still
-  charges no foreign transaction fees, which is unusual at this tier. Earning
-  is modest and narrow, at 2x miles on Delta purchases specifically and 2x on
-  dining, with everything else at 1x, so it is not a card to run all your
-  spending through. The signup bonus is small at 10,000 miles after $1,000 in
-  six months, which is a gentle requirement but not a reason to apply on its
-  own. What you do not get is the part that matters most to Delta flyers,
-  since there is no free checked bag or priority boarding here, and the
-  ongoing perks amount to 20% back on in-flight food and beverages and 10%
-  back on concessions at select stadiums, capped at $250 a year and requiring
-  enrollment. Keep it as a free way to hold a SkyMiles account open, and step
-  up to a paid Delta card if you check bags.
+  The Blue is the entry point to Delta's card lineup and the only one without
+  an annual fee, which is what earns it our Best No-Fee pick among airline
+  cards. You get 2x miles on Delta purchases and 2x at restaurants, 1x on
+  everything else, plus a 10,000-mile bonus after $1,000 of spend in the first
+  6 months and no foreign transaction fees. Ongoing perks are thin but real:
+  20% back as a statement credit on eligible Delta in-flight food and
+  beverages, and 10% back on concessions at select stadiums and arenas through
+  the Amex Venue Collection, capped at $250 per calendar year. What it does
+  not include is the benefit most Delta flyers actually want, a free checked
+  bag, which starts at the Gold. Carry the Blue if you fly Delta a few times a
+  year and refuse to pay an annual fee; if you check bags even twice a year,
+  price out the Gold instead.
 annual_fee: 0
 reward_type: "miles"
 tags:

--- a/data/cards/delta-skymiles-gold-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-american-express-card.yaml
@@ -7,19 +7,19 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Gold's case is straightforward Delta convenience for $150 a year: a free
-  first checked bag for you and up to eight companions on the same
-  reservation, Main Cabin 1 priority boarding, and 15% off award flights
-  booked through delta.com or the Fly Delta app. Earning is modest, 2x on
-  Delta purchases, restaurants, and U.S. supermarkets, with 1x on everything
-  else, so this is a benefits card more than a points engine. The welcome
-  offer briefly rose to 90,000 miles in June before settling back to 80,000
-  after $2,000 in six months, and Amex lists it as a variable as-high-as
-  figure, so your actual offer may come in lower. The $200 Delta flight credit
-  only arrives after $10,000 of purchases in a calendar year, a high bar if
-  the card is not your daily driver. If you check a bag on Delta a few times a
-  year, the bag fees alone can cover the fee; if you do not, the 20% inflight
-  rebate and $100 Delta Stays credit will not carry it.
+  The Gold's math is simple: a free first checked bag on Delta flights
+  worldwide and a free second bag domestically, for you and up to 8 companions
+  on the same reservation, which one family trip can cover against the $150
+  annual fee. Earning is decent for a co-brand at 2x miles on Delta purchases,
+  at restaurants, and at U.S. supermarkets, with 1x on everything else. The
+  welcome offer is currently as high as 80,000 miles after $3,000 in 6 months,
+  back down after briefly touching 90,000 in June, and Amex shows it as a
+  variable offer, so the amount you see may be lower. Ongoing credits include
+  up to $10 monthly on U.S. rideshare, up to $100 a year on Delta Stays
+  bookings, and a $200 Delta Flight Credit that only lands after $10,000 of
+  spend in a calendar year. It ranks fifth on our Best Airline Credit Cards
+  list, and the reason is the baggage benefit and priority boarding rather
+  than the earn rate.
 annual_fee: 150
 reward_type: "miles"
 benefits:

--- a/data/cards/delta-skymiles-gold-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-gold-business-american-express-card.yaml
@@ -7,20 +7,20 @@ apply_link: https://www.americanexpress.com/en-us/business/credit-cards/delta-sk
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  For $150 a year the Gold Business buys the same Delta travel perks as its
-  personal sibling: first checked bag free for you and up to eight companions,
-  Main Cabin 1 boarding, and 15% off award flights booked with Delta. The
-  business twist is 2x on U.S. shipping providers up to $50,000 a year,
-  alongside 2x on Delta purchases and restaurants worldwide, with everything
-  else at 1x. The welcome offer has been unusually volatile, swinging
-  between 60,000 and 90,000 miles through the spring and summer, and it
-  currently sits at the top of that range: 90,000 miles after $6,000 in six
-  months, as a limited-time offer running through November 4, 2026. If you have
-  been holding out for a better window, this is one. Watch the $200 Delta flight
-  credit too: it takes $10,000 in calendar-year purchases, which many
-  businesses will clear but casual users will not. The $150 Delta Stays credit
-  and up to $120 a year in rideshare credits help, though the rideshare credit
-  only starts after your first renewal.
+  For a small business that puts people on Delta flights, the Gold Business
+  pays for its $150 annual fee through baggage alone: a free first checked bag
+  worldwide and a free second bag domestically for the cardmember and up to 8
+  companions on the same reservation. Earning covers common business lines at
+  2x on Delta purchases, restaurants worldwide, and U.S. shipping providers,
+  with U.S. advertising in select media also at 2x under its own $50,000
+  annual cap, and 1x on everything else. The welcome offer is back at 90,000
+  miles after $6,000 in 6 months and ends November 4, 2026, though it has
+  bounced between 60,000 and 90,000 four times since May, so timing an
+  application around it is a gamble. Annual credits are useful but
+  conditional: up to $150 on Delta Stays bookings, up to $10 a month on U.S.
+  rideshare after your first renewal, and a $200 Delta Flight Credit that
+  requires $10,000 of spend in a calendar year. Fair value for a Delta-heavy
+  travel budget, thin if your team flies other airlines.
 category: "business"
 annual_fee: 150
 reward_type: "miles"

--- a/data/cards/delta-skymiles-platinum-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-american-express-card.yaml
@@ -7,20 +7,21 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/delta-skymiles-
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The annual companion certificate is what justifies the Platinum's $350 fee:
-  it is issued every year after renewal with no spend requirement and covers a
-  round-trip Delta Main Cabin ticket within the U.S. or to Mexico, the
-  Caribbean, or Central America. Around it you get 3x on Delta purchases and
-  hotels booked direct, 2x on dining and U.S. supermarkets, and 1x elsewhere,
-  plus a $2,500 MQD headstart and $1 of MQD per $20 spent if you are chasing
-  Medallion status. The welcome offer touched 100,000 miles in June and is
-  back to 90,000 after $3,000 in six months, quoted as an as-high-as number
-  that varies by applicant. The catch is that the math only works if you
-  actually redeem the certificate and use the recurring credits, since the
-  $150 Delta Stays, $120 Resy, and $120 rideshare credits arrive in $10
-  monthly slices or require booking through specific channels. If your travel
-  does not run through Delta, that 1x base rate makes this a weak everyday
-  card.
+  The annual companion certificate is the whole argument for the Platinum: it
+  arrives each year after renewal with no spend requirement and covers a
+  round-trip Delta Main Cabin flight within the U.S. or to Mexico, the
+  Caribbean, or Central America, which for most flyers exceeds the $350 annual
+  fee on its own. Earning is respectable at 3x miles on Delta purchases and on
+  hotels booked directly, 2x at restaurants and U.S. supermarkets, and 1x
+  elsewhere. Status chasers get the strongest piece: a $2,500 MQD headstart
+  each Medallion Qualification Year plus $1 MQD for every $20 of spend. The
+  welcome offer is currently as high as 90,000 miles after $4,000 in 6 months,
+  down from the 100,000 that ran briefly in June, and Amex sells it as a
+  variable offer, so your number may be lower. The credits, up to $10 a month
+  each on Resy dining and U.S. rideshare and $150 a year on Delta Stays, only
+  pay off if those merchants are already part of your routine, so judge the
+  card on the certificate and the MQD boost. It ranks fourth on our Best
+  Airline Credit Cards list.
 annual_fee: 350
 reward_type: "miles"
 benefits:

--- a/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-platinum-business-american-express-card.yaml
@@ -118,19 +118,18 @@ benefits:
     frequency: "per_claim"
     category: "insurance"
 our_take: >
-  The Platinum Business earns its $350 fee mainly through the annual companion
-  certificate, issued after each renewal for a round-trip Delta Main Cabin
-  ticket in the 48 contiguous states or to the Caribbean or Central America,
-  with taxes and fees of $22 to $250 left to you. Business spending picks up
-  1.5x on transit, U.S. shipping, and single purchases of $5,000 or more, up
-  to a combined $100,000 a year before it drops to 1x, on top of 3x on Delta
-  purchases and hotels booked directly. The welcome offer is currently
-  100,000 miles after $8,000 in six months, a limited-time raise from the usual
-  70,000 that runs through November 4, 2026. It is a heavier hurdle than the
-  Gold Business but with a deeper benefits stack behind it, including a $2,500
-  MQD headstart and a Global Entry credit every four years. Recurring credits run up to $200 at
-  Delta Stays, $120 at Resy, and $120 on rideshares, but they are metered out
-  monthly or tied to delta.com bookings, so treat them as a discount on the
-  fee rather than cash. Everything outside the bonus categories earns 1x,
-  which makes this a card for Delta loyalists and status chasers, not for
-  general business spend.
+  The business Platinum's welcome offer just jumped from 70,000 to 100,000
+  miles after $8,000 of spend in 6 months, and it is scheduled to end November
+  4, 2026, so this is an unusually good window to look at it. Beyond the
+  bonus, the recurring value is the annual companion certificate issued after
+  each renewal, good for a round-trip Delta Main Cabin ticket in the 48
+  contiguous states or to the Caribbean or Central America, with taxes and
+  fees from $22 to $250. Earning is 3x on Delta purchases and on hotels booked
+  directly with the property, then 1.5x on transit, U.S. shipping, and single
+  purchases of $5,000 or more up to a combined $100,000 a year, which suits a
+  business with lumpy equipment or vendor bills. Against the $350 annual fee,
+  the offsets are a $200 Delta Stays credit, up to $10 a month each on Resy
+  and U.S. rideshare, a Global Entry or TSA PreCheck credit every 4 years, and
+  a $2,500 MQD headstart toward Delta status. The gap to watch is that
+  everything outside those categories earns 1x, so it works as a Delta and
+  travel card rather than your primary business spend card.

--- a/data/cards/delta-skymiles-reserve-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-american-express-card.yaml
@@ -9,21 +9,23 @@ network: "amex"
 annual_fee: 650
 reward_type: "miles"
 our_take: >
-  We rank the Reserve the best premium pick among airline cards, and the
-  reason is lounge access plus a better certificate: 15 Delta Sky Club visits
-  per Medallion Year, unlimited after $75,000 in purchases, Centurion Lounge
-  entry when your Delta flight is booked on the card, and a yearly companion
-  certificate usable in Delta First, Premium Select, or Comfort rather than
-  Main Cabin only. Status chasers also get a $2,500 MQD headstart and $1 of
-  MQD per $10 spent, the strongest boost in the Delta lineup. What you do not
-  get is earning: 3x on Delta purchases and a flat 1x on everything else is
-  thin for a $650 fee. The welcome offer is now a two-part limited-time deal
-  running through November 4, 2026: two round-trip Delta Comfort certificates
-  plus 50,000 miles after $10,000 in six months. The spend hurdle doubled from
-  the $5,000 it sat at over the summer, but two Comfort round-trips are worth
-  more than the 50,000 miles they replace. Between $240 in Resy
-  credits, $200 in Delta Stays, and $120 in rideshare credits you can recover
-  a real chunk of the fee, but only if you spend in those exact channels.
+  The Reserve is bought for the lounge and status package, not the earn rate:
+  15 Delta Sky Club visits per Medallion Year with unlimited access after
+  $75,000 of purchases, Centurion Lounge access when your Delta flight is
+  booked on the card, an annual companion certificate that can be used in
+  Delta First or Premium Select, and a $2,500 MQD headstart plus $1 MQD per
+  $10 spent. Be clear about the earning: 3x miles on Delta purchases and 1x on
+  absolutely everything else, which is the weakest rate structure in the Delta
+  lineup and means this card should never carry your general spending. The
+  welcome offer was cut hard, from 100,000 miles to 50,000 in late August,
+  though it now pairs those miles with two round-trip Delta Comfort
+  certificates after $10,000 of spend in 6 months, and the whole offer ends
+  November 4, 2026. To justify the $650 annual fee you need to actually use
+  the credits, up to $20 a month on Resy dining, $200 a year on Delta Stays,
+  and up to $10 a month on rideshare, alongside the Sky Club visits. It ranks
+  thirteenth on our Best Airline Credit Cards list as our Best Premium pick,
+  which reflects a card built for frequent Delta flyers chasing Medallion
+  status rather than for points maximizers.
 benefits:
   - name: "Delta Sky Club Access"
     value: 0

--- a/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
+++ b/data/cards/delta-skymiles-reserve-business-american-express-card.yaml
@@ -119,19 +119,17 @@ benefits:
     category: "telecom"
     enrollment_required: false
 our_take: >
-  The Reserve Business carries the same $650 fee and the same lounge stack as
-  the personal version: 15 Delta Sky Club visits per Medallion Year, unlimited
-  after $75,000 in purchases, Centurion Lounge access on same-day Delta
-  tickets bought with the card, and an annual companion certificate good in
-  Delta First, Premium Select, Comfort+, or Main Cabin. It earns more broadly
-  than the personal Reserve, with 1.5x on transit, U.S. shipping, and U.S.
-  office supply stores, and every purchase moving to 1.5x once you pass
-  $150,000 in a calendar year. The welcome offer is at a high-water mark
-  through November 4, 2026: 200,000 miles after $20,000 in six months. That is
-  the steepest spend hurdle in the Delta lineup by a wide margin, so it only
-  makes sense if that spend is already on the calendar, but the payout is more
-  than double the usual 80,000.
-  Recurring credits cover up to $250 at Delta Stays, $240 at Resy, and $120 on
-  rideshares, plus a Global Entry credit every four years and a $2,500 MQD
-  headstart toward status. If your company does not fly Delta regularly, the
-  1x base rate below that $150,000 threshold makes the fee hard to justify.
+  The reason to look right now is the welcome offer: 200,000 miles after
+  $20,000 of spend in 6 months, raised from 80,000 in late August and set to
+  end November 4, 2026. That is a large enough haul to cover several years of
+  the $650 annual fee, but the $20,000 requirement means it only makes sense
+  for a business that can hit it without manufacturing spend. Ongoing, this is
+  a lounge and status card: 15 Delta Sky Club visits per Medallion Year with
+  unlimited access after $75,000 of purchases, Centurion Lounge access on
+  same-day Delta tickets bought with the card, an annual companion certificate
+  usable up to Delta First, a $2,500 MQD headstart, and $1 MQD per $10 spent.
+  The earn rate is the weak spot at 3x on Delta purchases, 1.5x on transit,
+  U.S. shipping, and U.S. office supply stores, and 1x on everything else
+  until $150,000 of annual purchases lifts the base to 1.5x. Credits worth up
+  to $250 a year on Delta Stays, $240 on Resy, and $120 on rideshare help
+  close the gap, but only count the ones your team will genuinely use.

--- a/data/cards/discover-it-cash-back.yaml
+++ b/data/cards/discover-it-cash-back.yaml
@@ -37,15 +37,14 @@ apply_link: https://www.discover.com/credit-cards/cash-back/it-card.html
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  The draw is the 5% rotating quarterly bonus, currently covering gas, EV
-  charging, transit, airlines, and drugstores on up to $1,500 in spending per
-  quarter, worth $75 back if you max it and remember to activate. Pair that
-  with 15 months of 0% intro APR on both purchases and balance transfers and
-  no annual fee, and you get a rare combination of payoff runway and real
-  rewards, which is why it lands at #7 on our best cash back list. The
-  tradeoff is that everything outside the bonus earns a flat 1%, so this works
-  as a supplement rather than a primary card, and the quarterly activation is
-  easy to forget. Discover acceptance is also narrower than Visa or
-  Mastercard, though there is no foreign transaction fee if you do travel. Set
-  a recurring reminder each quarter, and put your non-bonus spending on
-  something that beats 1%.
+  The draw is the 5% rotating category: through Q3 2026 that covers gas, EV
+  charging, transit, airlines and drugstores on up to $1,500 in spending each
+  quarter, with no annual fee and 15 months of 0% intro APR on both purchases
+  and balance transfers. That mix of a real payoff window and a strong
+  quarterly rate is why it lands at #7 on our Best Cash Back list. The catch
+  is the upkeep: you have to activate the category every quarter, remember
+  what it is, and stop at the $1,500 cap, after which the rate drops to 1%.
+  Everything outside the bonus category earns a flat 1%, below what a plain 2%
+  card pays, so this works best as a second card you route specific spending
+  through rather than your only one. There is no foreign transaction fee,
+  though the standard APR runs 17.49% to 26.49% once the intro window closes.

--- a/data/cards/discover-it-for-students-card.yaml
+++ b/data/cards/discover-it-for-students-card.yaml
@@ -34,17 +34,18 @@ apply_link: https://www.discover.com/credit-cards/student/it-card.html
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  The Cashback Match is what makes this worth a student's first application:
-  Discover matches all cash back earned in the first year with no cap, which
-  effectively turns the 5% rotating quarterly categories into 10% for year
-  one. Those categories currently cover gas, EV charging, transit, airlines,
-  and drugstores on up to $1,500 in spending per quarter, and they need to be
-  activated every quarter to count. There is no annual fee and no foreign
-  transaction fee, which matters if you spend a term abroad. The limits are
-  real, though: everything outside the rotating category earns 1%, the 0%
-  intro APR runs only six months on purchases, and the ongoing rate of 16.49%
-  to 25.49% is what applies after that. Use it to build history, activate each
-  quarter, and pay in full rather than leaning on that short intro window.
+  For a first card, the Cashback Match is the headline: Discover matches all
+  the cash back you earn in your first year with no cap, which effectively
+  doubles both the 5% rotating category and the 1% base rate for twelve
+  months. Through Q3 2026 that 5% covers gas, EV charging, transit, airlines
+  and drugstores on up to $1,500 in quarterly spending, and there is no annual
+  fee and no foreign transaction fee if you study abroad. The tradeoffs are
+  the usual rotating-category ones: you have to activate each quarter, and
+  anything past the cap or outside the category earns 1%. The 0% intro APR
+  runs only 6 months and applies to purchases alone, so treat it as a short
+  grace period rather than a payoff plan, especially with a regular rate of
+  16.49% to 25.49%. Use it to build history, pay in full each month, and
+  collect the match at the end of year one.
 benefits:
   - name: "Cashback Match"
     value: 0

--- a/data/cards/discover-it-miles.yaml
+++ b/data/cards/discover-it-miles.yaml
@@ -26,13 +26,15 @@ apply_link: https://www.discover.com/credit-cards/travel/
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  Discover it Miles keeps things simple: a flat 1.5x miles on every purchase,
-  no annual fee, and no foreign transaction fee, with nothing to activate or
-  track. Pair that with 15 months of 0% intro APR on both purchases and
-  balance transfers and it works for someone who wants light travel rewards
-  and a payoff runway from the same card. The limitation is that the flat 1.5x
-  is the entire rewards program: no bonus categories, no added travel perks,
-  nothing that rewards you for spending in one place over another. Once the
-  intro period ends the rate runs 17.49% to 26.49%, so the 0% window is the
-  part with a real deadline. It is a fine starter or backup card, but any
-  decent category card will out-earn it on gas, groceries, and dining.
+  The Discover it Miles is a simplicity play: 1.5 miles per dollar on
+  everything, no annual fee, no foreign transaction fee, and nothing to
+  activate or track. Pairing that flat rate with 15 months of 0% intro APR on
+  both purchases and balance transfers is unusual, so it can work as an
+  everyday card and a payoff card in the same year. The limitation is the
+  ceiling: 1.5x on all spending returns less than a plain 2% cash back card,
+  and there are no bonus categories anywhere to lift the average. There are no
+  travel benefits attached either, so treat the miles as a straightforward
+  travel credit rather than a points program with redemption upside. It is a
+  reasonable single-card setup for someone who values not thinking about it,
+  but it is not the highest-earning choice, and the regular APR of 17.49% to
+  26.49% waits at the end of the intro window.

--- a/data/cards/discover-it-secured-credit-card.yaml
+++ b/data/cards/discover-it-secured-credit-card.yaml
@@ -30,14 +30,14 @@ apply_link: https://www.discover.com/credit-cards/secured-credit-card/
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  The Discover it Secured is our top pick among secured cards because it
-  actually pays you while you rebuild: 5% back in rotating quarterly
-  categories on up to $1,500 in spend, which for Q3 2026 covers gas, EV
-  charging, transit, airlines, and drugstores. That is a real earn rate on a
-  card meant for people with thin or damaged credit, and there is no annual
-  fee and no foreign transaction fee to erode it. The catches are ordinary but
-  worth naming: you have to activate the 5% categories every quarter, spending
-  past the $1,500 cap drops to 1%, and everything outside the rotating list
-  earns a flat 1%. The 26.49% regular APR is steep, so this only works if you
-  pay in full each month, which is the habit the card exists to build in the
-  first place. Treat it as a stepping stone, not a forever card.
+  This is the rare secured card that earns like an unsecured one: the same 5%
+  rotating category Discover runs on its mainstream cards, covering gas, EV
+  charging, transit, airlines and drugstores through Q3 2026 on up to $1,500
+  per quarter, plus 1% on everything else and no annual fee. That earning
+  power on a deposit-backed card is why it sits at #1 on our Best Secured
+  Credit Cards list. The costs are real, though: the APR is a flat 26.49% with
+  no intro period at all, so carrying a balance here is expensive, and you
+  have to activate the bonus category each quarter to get the 5%. You also
+  need cash on hand for the security deposit, which is the practical barrier
+  for a lot of people rebuilding. Keep the charges small, pay in full every
+  month, and the rewards become a genuine bonus on top of the credit building.

--- a/data/cards/discover-it-student-chrome-card.yaml
+++ b/data/cards/discover-it-student-chrome-card.yaml
@@ -38,14 +38,15 @@ apply_link: https://www.discover.com/credit-cards/student/chrome-card.html
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  The Student Chrome keeps things simple for a first card: 2% back at gas
-  stations and restaurants on up to $1,000 in combined spend each quarter, 1%
-  on everything else, and no annual fee. For a student whose budget is mostly
-  food and fuel, that combined $1,000 quarterly cap is realistically hard to
-  outgrow, and the absence of a foreign transaction fee makes it usable on a
-  semester abroad. The 6 months of 0% intro APR on purchases is short, more of
-  a cushion for a laptop or textbooks than a real financing runway, and the
-  16.49% to 25.49% regular rate takes over quickly after that. There is no
-  signup bonus, so the value here is entirely in the ongoing earn and the
-  credit history you build. Use it for gas and dining, pay it off monthly, and
-  graduate to something stronger once your file matures.
+  Chrome trades the rotating-category chase for something simpler: a flat 2%
+  back at gas stations and restaurants on up to $1,000 in combined spending
+  each quarter, then 1% after that and on everything else. For a student whose
+  spending is mostly food and getting around, that is a fair match, and there
+  is no annual fee and no foreign transaction fee if you spend a semester
+  overseas. The ceiling is low, though: $1,000 a quarter across both
+  categories is roughly $333 a month, which caps the bonus categories at about
+  $20 back per quarter. The 0% intro APR lasts only 6 months and applies to
+  purchases alone, and the regular rate runs 16.49% to 25.49%, so this is a
+  card for building history rather than carrying a balance. Choose it if you
+  want rewards you never have to activate, and choose the rotating-category
+  student version instead if you will actually do the quarterly work.

--- a/data/cards/disney-inspire-visa.yaml
+++ b/data/cards/disney-inspire-visa.yaml
@@ -97,19 +97,17 @@ apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/inspire
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Inspire is built for households that spend heavily and predictably on
-  Disney: 10% back on Disney+, Hulu, and ESPN+ specifically, 3% at most U.S.
-  Disney locations, 3% on gas, and 2% on groceries and dining, with 1% on
-  everything else. Stack that with the $120 in annual streaming credits ($10
-  monthly when you spend at least $10 on those services, with yearly
-  enrollment) and the $100 park ticket credit after $200 in U.S. Disney ticket
-  spend, and the $149 annual fee can be covered before you earn a single
-  point. Chase recently cut the welcome offer from $600 to $500, now a $300
-  Disney eGift Card at approval plus a $200 statement credit after $1,000 in
-  the first 3 months. The honest limit is that the standout rates are narrow:
-  the 10% applies only to those three streaming services and the 3%
-  entertainment rate only at Disney locations, so a non-Disney household is
-  left with 3% gas, 2% groceries and dining, and a $149 bill. There is no
-  foreign transaction fee, and the 200 Disney Rewards Dollars for $2,000 at
-  Disney resorts or the cruise line only matters if you already book those
-  trips.
+  The Inspire only makes sense if Disney is a recurring line in your budget,
+  but for that household the credits can outrun the $149 annual fee: $120 a
+  year in streaming credits at $10 a month on Disney+, Hulu or ESPN+ with
+  annual enrollment, plus a $100 statement credit after $200 in U.S. Disney
+  theme park tickets each anniversary year. The earn rates lean the same way,
+  since the 10% applies only to Disney+, Hulu and ESPN+ purchases and the 3%
+  entertainment rate only at most U.S. Disney locations, leaving 3% on gas, 2%
+  on groceries and dining, and 1% on everything else. The welcome offer was
+  recently trimmed from $600 to $500, now a $300 Disney eGift Card on approval
+  plus a $200 statement credit after $1,000 in the first three months. The
+  catch is that nearly all of the value is locked to one brand, and a 1% base
+  rate makes this a poor everyday card, so occasional park visitors will
+  struggle to earn the fee back. There is no foreign transaction fee, and the
+  standard APR runs 18.24% to 27.74%.

--- a/data/cards/disney-premier-visa-card.yaml
+++ b/data/cards/disney-premier-visa-card.yaml
@@ -80,19 +80,20 @@ benefits:
     category: "travel"
     enrollment_required: false
 our_take: >
-  The Premier is the middle Disney card, and at a $49 annual fee it asks much
-  less to prove itself than its bigger sibling: 5% back on Disney+, Hulu, and
-  ESPN+, 2% at most U.S. Disney locations, and 2% on gas, groceries, and
-  dining, with 1% on everything else. The welcome offer is easy to clear at
-  $300 total, a $200 Disney eGift Card at approval plus a $100 statement
-  credit after just $500 in the first 3 months, which alone covers the fee for
-  years one and two. Just be precise about what earns what: the 5% is gated to
-  those three streaming services and the 2% entertainment rate only applies at
-  Disney locations, so this is not a broad 2% card. It also charges foreign
-  transaction fees, which is an odd omission on a card aimed at travelers and
-  rules it out for international park trips. The park discounts, 10% on select
-  merchandise purchases of $50 or more and on select dining, are pleasant but
-  small.
+  At $49 a year the Premier is the middle option in Chase's Disney lineup, and
+  the welcome offer alone covers several years of that fee: a $200 Disney
+  eGift Card on approval plus a $100 statement credit after $500 in the first
+  three months. Ongoing, the 5% rate is limited to Disney+, Hulu and ESPN+
+  purchases and the 2% entertainment rate applies at most U.S. Disney
+  locations, with a broader 2% on gas, groceries and dining and 1% on
+  everything else. The in-park discounts help on a trip: 10% off select
+  merchandise purchases of $50 or more, 10% off select dining, and 15% off
+  select guided tours at Disneyland and Walt Disney World. Two things hold it
+  back. The card charges foreign transaction fees, which is awkward given how
+  much of its value points at travel and cruises, and the 1% floor on
+  non-bonus spending sits well below a plain 2% card, so once the sign-up
+  value is banked, keep it only if the Disney rates and discounts genuinely
+  fire for you.
 apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/premier
 foreign_transaction_fee: true
 network: "visa"

--- a/data/cards/disney-visa-card.yaml
+++ b/data/cards/disney-visa-card.yaml
@@ -24,18 +24,19 @@ apply_link: https://creditcards.chase.com/rewards-credit-cards/disney/rewards
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The no annual fee Disney Visa is a fan card first and a rewards card a
-  distant second: it earns a flat 1% in Disney Rewards Dollars on everything,
-  with no bonus categories at all. What makes it worth a look is the entry
-  price, since the $150 welcome offer, a $100 Disney eGift Card at approval
-  plus a $50 statement credit after $500 in the first 3 months, costs you
-  nothing in annual fees to collect. The in-park perks carry the rest of the
-  case: 10% off select merchandise and select dining at Disneyland and Walt
-  Disney World, 15% off select guided tours, and a complimentary one-year
-  DoorDash DashPass membership. Be clear that 1% is a below-market base rate,
-  and the card charges foreign transaction fees, so it should never be your
-  everyday spender. Keep it for Disney purchases and the discounts, and put
-  general spending on something that pays more.
+  The no-fee Disney Visa is really an access card: the sign-up offer of a $100
+  Disney eGift Card on approval plus a $50 statement credit after $500 in
+  three months, and then the cardmember perks, are the reasons to hold it.
+  Those perks include 10% off select merchandise and select dining at
+  Disneyland and Walt Disney World, 15% off select guided tours, 10% at
+  DisneyStore.com, and a complimentary one-year DoorDash DashPass membership
+  that requires enrollment. The earning is the weak part: a flat 1% in Disney
+  Rewards Dollars on every purchase with no bonus categories, which is half
+  what an ordinary 2% cash back card returns. It also charges foreign
+  transaction fees, so it should stay home on international trips, and the
+  standard APR of 18.24% to 27.74% makes it an expensive place to carry a
+  balance. Keep it for the park discounts and the welcome offer, and put your
+  real spending on something that pays more.
 benefits:
   - name: "DoorDash DashPass"
     value: 0

--- a/data/cards/fidelity-rewards-visa-signature.yaml
+++ b/data/cards/fidelity-rewards-visa-signature.yaml
@@ -26,18 +26,19 @@ apply_link: https://www.fidelity.com/spend-save/visa-signature-card
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Fidelity Rewards Visa Signature is one of the cleanest flat-rate cards
-  available: 2% back on every purchase with no annual fee, no categories to
-  track, and no foreign transaction fee. The condition worth understanding is
-  that the 2% rate depends on rewards being deposited into an eligible
-  Fidelity account, so this really works best if you already bank or invest
-  with Fidelity and want cash back funneled straight into savings or a
-  brokerage. The up to $100 in Reward Points toward a Global Entry or TSA
-  PreCheck application every five years is a genuine extra on a card that
-  charges nothing to hold. Note that the signup bonus, previously $150, was
-  removed in July 2026, so there is no welcome offer to chase right now. The
-  16.49% to 26.49% regular APR is unremarkable, which is fine for a card you
-  carry for its steady base rate rather than for financing.
+  The Fidelity Rewards Visa Signature is a clean 2% flat cash back card with
+  no annual fee, with one condition: the full 2% comes when rewards are
+  deposited into an eligible Fidelity account. If you already bank or invest
+  with Fidelity that is a formality, and the automatic sweep into a brokerage
+  or retirement account is a useful habit in itself, but if you do not, the
+  account requirement is friction for a rate you can get elsewhere with no
+  strings. It also charges no foreign transaction fee and offers up to $100 in
+  reward points toward a Global Entry or TSA PreCheck application fee once
+  every five years, which is unusual on a card that costs nothing to hold. The
+  welcome offer is gone, though: the previous $150 bonus was removed in July
+  2026, so there is no upfront incentive to open it right now. Treat it as a
+  long-term everyday card for Fidelity customers rather than a bonus play, and
+  note the regular APR of 16.49% to 26.49% if you ever carry a balance.
 benefits:
   - name: "Global Entry or TSA PreCheck Credit"
     value: 100

--- a/data/cards/free-spirit-travel-mastercard.yaml
+++ b/data/cards/free-spirit-travel-mastercard.yaml
@@ -36,16 +36,14 @@ benefits:
     description: "Zone 2 shortcut boarding on Spirit flights."
     category: "travel"
 our_take: >
-  The no annual fee Free Spirit Travel is no longer accepting applications, so
-  this is a reference point for existing cardholders rather than something to
-  go get. Its best feature was always the cost of entry rather than the earn:
-  2 points per dollar on eligible Spirit Airlines purchases and 1 point per
-  dollar on everything else, with no foreign transaction fee. The 2x rate
-  applies only to Spirit purchases, so unless you fly Spirit regularly the
-  card is effectively a 1x card, which is hard to justify keeping open for
-  anything but credit history. Perks are modest and Spirit-specific: a 25%
-  rebate on inflight food and beverages, Zone 2 shortcut boarding, and 5,000
-  anniversary bonus points that require $10,000 in spend during the prior
-  year, a threshold most holders of a card like this will never hit. If you
-  still carry it, use it for Spirit tickets and inflight purchases and put the
-  rest of your spending elsewhere.
+  The pitch here was a no annual fee way to earn Free Spirit points, and the
+  card is no longer accepting applications, so this is a review for existing
+  holders rather than a shopping recommendation. The 2x rate applies only to
+  eligible Spirit Airlines purchases, and everything else earns a flat 1 point
+  per dollar, which is a thin base rate for a card you would use outside of
+  booking flights. The perks are modest but real if you fly Spirit often: Zone
+  2 shortcut boarding, a 25% rebate on inflight food and drinks paid with the
+  card, and 5,000 anniversary points that require $10,000 of spend in the
+  prior year to trigger. No foreign transaction fee is a small plus for
+  international Spirit routes. If you are not a repeat Spirit flyer, there is
+  very little reason to put spend on this one.

--- a/data/cards/free-spirit-travel-more-world-elite-mastercard.yaml
+++ b/data/cards/free-spirit-travel-more-world-elite-mastercard.yaml
@@ -52,17 +52,15 @@ benefits:
     description: "Free Spirit points could be pooled with up to eight friends or family members."
     category: "travel"
 our_take: >
-  The Free Spirit Travel More is closed to new applicants, which matters
-  because its perks were the reason to hold it: two free checked bags on
-  Spirit flights, added in September 2025, plus shortcut boarding and a 25%
-  rebate on inflight food and beverages. For a frequent Spirit flyer, the
-  checked bag benefit alone can outrun the $79 annual fee, which was waived
-  for the first 12 months. Earning is narrower than the point totals suggest:
-  3 points per dollar applies only to Spirit tickets and inflight purchases,
-  with 2x on dining and groceries and 1x on everything else, so this is a
-  Spirit loyalty card rather than a general travel earner. The $100 companion
-  flight voucher at each anniversary requires $5,000 in spend the prior year
-  and does not cover taxes and fees, so treat it as conditional rather than
-  automatic. Existing cardholders who fly Spirit a few times a year should
-  keep it for the bags; anyone who has drifted away from the airline is paying
-  $79 for very little.
+  This was the upgraded Free Spirit card, and its best feature for a frequent
+  Spirit flyer is two free checked bags, which can cover the $79 annual fee in
+  a single roundtrip on an airline that charges for everything. It also earns
+  3x on Spirit tickets and inflight purchases only, plus 2x on dining and
+  groceries and 1x on everything else, so the higher rate is narrower than it
+  looks. The annual fee is waived for the first 12 months, and a $100
+  companion flight voucher arrives at each anniversary if you spent $5,000 in
+  the prior year, with taxes and fees still on you. Shortcut boarding, a 25%
+  inflight food and beverage rebate, points pooling with up to eight people,
+  and no foreign transaction fee round it out. The catch is that the card is
+  closed to new applications, and all of the value is locked to one ultra low
+  cost carrier.

--- a/data/cards/gemini-credit.yaml
+++ b/data/cards/gemini-credit.yaml
@@ -41,12 +41,13 @@ apply_link: https://www.gemini.com/credit-card
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The draw here is 4% back on gas, EV charging, and transit with no annual
-  fee, a strong rate in categories most cash back cards ignore. The catch is
-  the cap: those three share a single $300 in monthly spend, so the 4% is
-  worth at most $12 a month before the rate drops to 1%, and the cap resets on
-  the 1st. Dining at 3% and groceries at 2% carry no cap, and there is no
-  foreign transaction fee, so the card travels fine. There is no signup bonus,
-  and the regular APR runs from 16.49% to 34.49%, so this only makes sense if
-  you pay in full each month. Treat it as a targeted commuting card alongside
-  a stronger everyday earner rather than as your only cash back card.
+  The reason to carry this one is the 4% back on gas, EV charging, and
+  transit, a combination few no annual fee cards pay at that rate. Read the
+  cap closely: those three share a single $300 of spend per month, which is
+  $12 of cash back at most, and anything past it drops to 1%. Below that, 3%
+  on dining and 2% on groceries are respectable everyday rates, but the 1%
+  base on everything else means this is a category card, not a catch all.
+  There is no annual fee and no foreign transaction fee, so keeping it around
+  costs nothing. The regular APR runs from 16.49% to 34.49%, and that top end
+  is steep enough that this card only makes sense if you pay in full each
+  month.

--- a/data/cards/graphite-business-cash-unlimited.yaml
+++ b/data/cards/graphite-business-cash-unlimited.yaml
@@ -10,17 +10,17 @@ apply_link: "https://www.americanexpress.com/us/credit-cards/business/business-c
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  Amex built this one around a single number: unlimited 2% cash back on
-  eligible purchases, plus 5% on flights and prepaid hotels booked through
-  American Express Travel. The problem is that plenty of business cards pay a
-  flat 2% with no annual fee, so the $295 here has to be earned somewhere
-  else, and that somewhere is volume. The welcome offer is $1,500 after
-  $50,000 in six months, and the One AP statement credits, worth up to $2,400
-  a year, only begin after $250,000 in eligible purchases in a calendar year.
-  If your business genuinely runs six figures through a card annually, the
-  math works; below that you are paying a premium fee for a rate available for
-  free. No foreign transaction fees and a 17.74% to 28.49% regular APR round
-  it out.
+  The core of this card is a flat 2% cash back on eligible purchases with no
+  category tracking, which is the right shape for a business with spend that
+  does not sort neatly into buckets. American Express Travel bookings earn 5%
+  on flights and prepaid hotels, but that rate only applies through the Amex
+  portal, not to bookings made directly with the airline or property. The $295
+  annual fee is the first hurdle: at 2%, you need roughly $15,000 of annual
+  spend just to break even against a no fee 2% alternative. The signup bonus
+  is $1,500 after $50,000 of spend in six months, a high bar aimed squarely at
+  larger businesses, and the One AP statement credits of up to $2,400 require
+  $250,000 of purchases in a calendar year. There is no foreign transaction
+  fee, and the regular APR runs 17.74% to 28.49%.
 tags:
   - business
   - cashback

--- a/data/cards/hawaiian-airlines-business-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-business-mastercard.yaml
@@ -38,18 +38,19 @@ signup_bonus:
   spend_requirement: 4000
   timeframe_months: 3
 our_take: >
-  The clearest reason to carry this card is 3x on Hawaiian Airlines and Alaska
-  Airlines purchases, paired with 2x on gas, dining, and office supplies and a
-  50,000-mile bonus after $4,000 in three months, all for a $99 annual fee.
-  That 3x is merchant-gated, though: it applies to those two airlines
-  specifically, not to travel in general, and everything outside the bonus
-  categories earns a flat 1x. The annual spend bonuses are built for heavy
-  users, at 20,000 Atmos Rewards points for $50,000 in a calendar year and
-  40,000 for $100,000, so most small businesses will never reach them. The
-  one-time 50% off companion discount on roundtrip main cabin travel is real
-  first-year value, but it does not repeat. Worth the fee if you fly Hawaiian
-  or Alaska often enough to use the 3x and the companion discount; otherwise a
-  flat-rate business card will earn more on ordinary spend.
+  For a business that flies Hawaiian or Alaska, this card earns 3x on
+  purchases with those two airlines and comes with a 50,000 mile signup bonus
+  after $4,000 of spend in three months, which is a low spend requirement for
+  a bonus that size. The everyday rates are reasonable for a $99 airline card:
+  2x on gas, dining, and office supplies, with 1x on everything else. Be
+  honest about the airline rate, though, because the 3x applies only at
+  Hawaiian and Alaska and not to travel generally, so this is not a card for
+  booking other carriers. The annual spend bonuses reward volume rather than
+  loyalty: 20,000 Atmos Rewards points at $50,000 of calendar year spend, or
+  40,000 at $100,000 instead. A one-time 50% off companion discount on
+  roundtrip main cabin travel and no foreign transaction fee make it easier to
+  justify the fee in year one, and the regular APR of 19.49% to 29.49% means
+  you want to carry no balance.
 
 apr:
   regular:

--- a/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
+++ b/data/cards/hawaiian-airlines-world-elite-mastercard.yaml
@@ -44,18 +44,19 @@ apr:
     max: 29.99
 our_take: >
   Two free checked bags for the cardmember on eligible Hawaiian and Alaska
-  operated flights is the benefit that most reliably covers the $99 annual
-  fee, and the 50,000-mile bonus after just $2,000 in three months is one of
-  the easier spend requirements on an airline card, which is part of why it
-  lands eighth on our Best Airline Credit Cards list. Note that the 3x applies
-  only to Hawaiian Airlines purchases, so outside of that you are earning 2x
-  on gas, dining, and groceries and 1x on everything else, which is thin for a
-  card with a fee. The $100 anniversary companion discount on a roundtrip
-  between Hawaii and North America and the one-time 50% off companion discount
-  both help, but only if you actually make that trip. There is also 15 months
-  of 0% intro APR on balance transfers, unusual for an airline card and worth
-  knowing if you are carrying a balance. Regular APR runs 20.24% to 29.99%, so
-  the intro window is the only cheap money here.
+  operated flights is the practical case for this card, and it can pay back
+  the $99 annual fee on one roundtrip. The 50,000 mile signup bonus after only
+  $2,000 of spend in three months is an unusually easy target, and it is
+  joined by a $100 companion discount for a roundtrip between Hawaii and North
+  America at each anniversary plus a one-time 50% off companion discount.
+  Earning is airline specific: 3x applies to Hawaiian Airlines purchases only,
+  with 2x on gas, dining, and groceries and 1x on everything else, so this is
+  a card to use around your Hawaii travel, not for it to carry all your spend.
+  It ranks 11th on our Best Airline Credit Cards list, which is about right
+  for a card whose value depends entirely on flying one route network. There
+  is no foreign transaction fee, and a 15 month 0% intro APR on balance
+  transfers is a bonus rather than a reason to apply, given the 20.24% to
+  29.99% regular rate afterward.
 benefits:
   - name: "Two Free Checked Bags"
     value: 0

--- a/data/cards/heb-visa-signature.yaml
+++ b/data/cards/heb-visa-signature.yaml
@@ -38,14 +38,14 @@ benefits:
     frequency: "ongoing"
     category: "other"
 our_take: >
-  For H-E-B shoppers the headline is 5% back, but the fine print matters: it
-  applies only to H-E-B and Central Market own-brand products in-store and on
-  heb.com, plus Favor delivery orders, and it excludes pharmacy prescriptions,
-  fuel, gift cards, and in-store restaurants. Name-brand items in the same
-  cart earn the base rate, not 5%. That base rate is a respectable 1.5% on
-  everything else with no annual fee and no foreign transaction fee, which
-  makes the card easy to keep even if your store-brand spend is modest. Earned
-  cash back never expires for the life of the account, and you get the
-  standard Visa Signature package of concierge, Luxury Hotel Collection,
-  rental car privileges, and travel assistance. The regular APR tops out at
-  35.99%, so this works only as a pay-in-full card.
+  If you shop H-E-B regularly, the 5% back is the draw, but the fine print
+  narrows it a lot: it applies to H-E-B and Central Market own-brand products
+  in store and on heb.com plus Favor delivery orders, and it excludes pharmacy
+  prescriptions, fuel, gift cards, and in-store restaurants. Name brands in
+  your cart do not earn the top rate, so treat 5% as a store-brand rebate
+  rather than a grocery rate. What makes the card easier to keep is the 1.5%
+  on everything else, which is a decent flat base for a store card and better
+  than most, alongside no annual fee and no foreign transaction fee. Cash back
+  does not expire for the life of the account, and Visa Signature adds
+  concierge, hotel collection, and travel assistance perks you may never use.
+  The regular APR tops out at 35.99%, so this is a pay-in-full card only.

--- a/data/cards/hilton-honors-american-express-aspire-card.yaml
+++ b/data/cards/hilton-honors-american-express-aspire-card.yaml
@@ -7,19 +7,20 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors-a
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Aspire's case rests on credits rather than earn rates: an annual free
-  night at most Hilton properties, up to $400 a year in resort credits issued
-  as $200 semiannually, up to $200 a year in flight credits at $50 per
-  quarter, up to $219 for CLEAR Plus, and complimentary Diamond status. Stack
-  that against the $550 annual fee and it holds up, but only if you will
-  actually use the free night and spend at participating Hilton resorts, since
-  the credits are capped by period and do not roll over. The current welcome
-  offer is 150,000 points after $6,000 in six months, cut back from 175,000 at
-  the end of July, so there is no reason to rush an application at this level.
-  Away from Hilton you earn 7x on flights, car rentals, and U.S. restaurants
-  and 3x on everything else, useful only if you value Hilton points highly.
-  Heavy spenders can also pick up additional free night rewards at $30,000 and
-  $60,000 in a calendar year.
+  The Aspire justifies its $550 annual fee through credits rather than
+  spending: an annual Free Night Award, up to $400 in Hilton resort credits
+  split across two halves of the year, up to $200 in flight credits at $50 a
+  quarter, and up to $219 for CLEAR Plus. Automatic Hilton Honors Diamond
+  status is the other pillar, bringing upgrades, lounge access, and late
+  checkout without a stay requirement. Earning is strong where it counts, at
+  14x on eligible Hilton purchases, with 7x on flights, car rentals, and U.S.
+  restaurants and 3x on everything else, though the 14x applies only at Hilton
+  properties. The signup bonus is 150,000 points after $6,000 in six months,
+  back down after briefly running at 175,000 between May and the end of July.
+  The honest catch is that the credits arrive in quarterly and semiannual
+  slices, so you only come out ahead if your travel actually fits that
+  calendar and you stay at Hilton enough to value the Diamond status and free
+  night.
 annual_fee: 550
 reward_type: "points"
 rewards:

--- a/data/cards/hilton-honors-american-express-business-card.yaml
+++ b/data/cards/hilton-honors-american-express-business-card.yaml
@@ -55,16 +55,16 @@ benefits:
     frequency: "ongoing"
     category: "hotel"
 our_take: >
-  The unusual thing about this card is its base rate: 5x Hilton Honors points
-  on everything for the first $100,000 in purchases each calendar year,
-  dropping to 3x after that, on top of 12x at Hilton properties. That 5x floor
-  is what separates it from most $195 hotel cards, which reserve their best
-  rates for narrow categories. Up to $240 a year in Hilton credits, paid out
-  as $60 per quarter, covers most of the fee if you stay with the brand often
-  enough to use it every quarter rather than in one burst. Complimentary Gold
-  status brings room upgrades when available and a daily food and beverage
-  credit, and $40,000 in eligible purchases in a calendar year moves you to
-  Diamond. The 130,000-point offer after $6,000 in six months was flagged as a
-  limited-time deal running through July 29, 2026, with the first year's fee
-  waived, so confirm what is actually on the application page before you count
-  on it.
+  The standout here is the base rate: 5x Hilton Honors points on everything
+  for the first $100,000 of purchases each calendar year, then 3x, which is a
+  genuinely high earn on ordinary business spend rather than a narrow category
+  bonus. Purchases directly with Hilton properties earn 12x, and the signup
+  bonus is 130,000 points after $6,000 in six months. Against the $195 annual
+  fee you get up to $60 back each quarter on Hilton purchases, worth up to
+  $240 a year if your stays are spread across the calendar, plus complimentary
+  Gold status with room upgrades, a daily food and beverage credit, and an 80%
+  bonus on base points. Diamond status is available but only after $40,000 of
+  eligible purchases in a calendar year. The tradeoff is that everything you
+  earn is Hilton points, which are worth less per point than transferable
+  currencies, so the 5x is less generous than the number suggests unless you
+  redeem for Hilton stays.

--- a/data/cards/hilton-honors-american-express-surpass-card.yaml
+++ b/data/cards/hilton-honors-american-express-surpass-card.yaml
@@ -8,20 +8,20 @@ foreign_transaction_fee: false
 network: "amex"
 annual_fee: 150
 our_take: >
-  The Surpass sits in the sweet spot of the Hilton lineup: 12x at Hilton
-  hotels and resorts and 6x at U.S. restaurants, U.S. supermarkets, and U.S.
-  gas stations, rates that hold up against cards charging far more than its
-  $150 annual fee. Up to $200 a year in Hilton credits, released as $50 per
-  quarter, covers most of the fee on its own if your Hilton stays are spread
-  across the year, and complimentary Gold status adds room upgrades, late
-  checkout, and 5th night free on reward stays. The welcome offer is 130,000
-  points plus a Free Night Reward after $3,000 in six months, a low spend
-  requirement for a bonus that size. The limits are real: the credits expire
-  quarterly rather than pooling, and the free night at $15,000 and Diamond
-  status at $40,000 in a calendar year are out of reach for most cardholders.
-  Take it over the no-fee Hilton card if you stay with the brand a few nights
-  a year, and over the Aspire if you will not travel enough to use that card's
-  larger credits.
+  The Surpass is the middle Hilton card, and the reason to pick it is the
+  everyday earn: 6x at U.S. restaurants, U.S. supermarkets, and U.S. gas
+  stations, 4x on eligible U.S. online retail, and 3x on everything else, with
+  12x reserved for eligible purchases at Hilton properties. The signup bonus
+  is 130,000 points plus a Free Night Reward after $3,000 of spend in six
+  months, which is a low requirement relative to the size of the offer. Up to
+  $50 per quarter in Hilton credits can offset most of the $150 annual fee,
+  but only if you have a Hilton charge in each of the four quarters, and
+  unused quarters do not roll forward. Complimentary Gold status with
+  upgrades, late checkout, and fifth night free on award stays is the ongoing
+  perk that matters most; Diamond requires $40,000 of annual spend, and a
+  second Free Night Reward requires $15,000. Hilton points carry modest per
+  point value, so weigh the 6x categories against a card earning transferable
+  points at a lower rate.
 reward_type: "points"
 rewards:
   - category: hotels

--- a/data/cards/hilton-honors-card.yaml
+++ b/data/cards/hilton-honors-card.yaml
@@ -7,19 +7,19 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/hilton-honors/
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  For a card with no annual fee the earn structure is genuinely good: 7x at
-  Hilton hotels and resorts, 5x at U.S. restaurants, U.S. supermarkets, and
-  U.S. gas stations, and 3x on everything else. The current welcome offer is
-  80,000 points plus a $100 statement credit after $2,000 in six months, which
-  is back down after briefly reaching 100,000 in the spring and being trimmed
-  at the end of July, so waiting for the next bump costs you nothing. The
-  tradeoff is what is missing: complimentary status stops at Silver, Gold
-  arrives only after $20,000 in eligible purchases in a calendar year, and
-  there is no free night, no resort credit, and no lounge access. Since there
-  is no fee, it is an easy card to keep open for the Hilton and everyday
-  category rates. But if you stay with Hilton often enough to care about
-  status and credits, the fee-charging versions of this card do considerably
-  more.
+  For a card with no annual fee, the earn structure is unusually good: 5x at
+  U.S. restaurants, U.S. supermarkets, and U.S. gas stations, 3x on everything
+  else, and 7x on eligible Hilton purchases. The current welcome offer is
+  80,000 points plus a $100 statement credit after $2,000 of spend in six
+  months, which is down from the 100,000 that ran between late May and the end
+  of July, so the timing is not ideal but the offer is still substantial for a
+  free card. The status is where expectations should stay low: you get Silver,
+  which mainly means fifth night free on award stays, and reaching Gold takes
+  $20,000 of eligible purchases in a calendar year. Hilton points are worth
+  less than most transferable currencies, so a 5x grocery rate here is not
+  automatically better than a 3x or 4x rate earning flexible points. Still,
+  with nothing to pay each year and no foreign transaction fee, it is a
+  reasonable keeper for anyone who stays at Hilton at all.
 card_referral_link: "https://www.americanexpress.com/en-us/credit-cards/referral/prospect/hilton-honors/personal?ref="
 annual_fee: 0
 reward_type: "points"

--- a/data/cards/iberia-visa-signature-card.yaml
+++ b/data/cards/iberia-visa-signature-card.yaml
@@ -8,18 +8,18 @@ foreign_transaction_fee: false
 network: "visa"
 reward_type: "miles"
 our_take: >
-  The draw here is 75,000 Avios after $5,000 of spend in three months, which
-  is a large opening haul for a $95 airline card with no foreign transaction
-  fees. Ongoing earning is narrow though: 3x applies only to Iberia, British
-  Airways, and Aer Lingus flights, 2x to hotels booked directly, and
-  everything else drops to 1x, so this is not a card you put daily spend on.
-  The companion voucher sounds generous at up to $1,000 for two seats on the
-  same Iberia flight, but it takes $30,000 of purchases in a calendar year to
-  trigger, which puts it out of reach for most people paying the $95 fee. The
-  10% discount on Iberia flights booked through the cardmember site and the
-  baggage delay and lost luggage coverage are the practical everyday extras.
-  Worth it if you actually fly Iberia or British Airways and value Avios;
-  otherwise the signup bonus is the whole story.
+  The Iberia Visa Signature is a narrow card built for one thing: earning
+  Avios on the Iberia side of the British Airways family, at 3 points per
+  dollar on Iberia, British Airways, and Aer Lingus flights. Beyond that it
+  pays 2 points per dollar on hotels booked directly and 1 point on everything
+  else, so it is not a card you spend on day to day. The current 75,000-mile
+  bonus after $5,000 in three months is the main reason to open it, and there
+  is no foreign transaction fee to worry about abroad. The headline companion
+  voucher, worth up to $1,000 toward two tickets on the same Iberia flight,
+  requires $30,000 of spend in a calendar year, which is a real hurdle for
+  most people and the honest catch behind the $95 annual fee. If you fly
+  Iberia often enough to hit that threshold, the math works; if you do not,
+  this is a bonus-and-close card.
 tags:
   - airline
   - travel

--- a/data/cards/ihg-rewards-club-premier-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-premier-credit-card.yaml
@@ -113,18 +113,19 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/ihg-rewards-club/p
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  For a $99 annual fee, the Premier hands you an anniversary free night good
-  at properties costing up to 40,000 points, automatic Platinum Elite status,
-  and a 4th reward night free on point stays, which is a lot of hotel value
-  for the price. The current 140,000-point bonus after $3,000 in three months,
-  plus 10,000 more for adding an authorized user, is what lands it at #4 on
-  our Best Signup Bonuses list, though be aware the offer peaked at 185,000
-  points in June and was cut back to 140,000 in July. Earning is unusually
-  strong for a hotel card: 10x at IHG properties (up to 26x once elite and
-  member bonuses stack), 5x on travel, gas, and dining, and 3x on everything
-  else with no foreign transaction fee. Side benefits pile up too, including a
-  $120 Global Entry or TSA PreCheck credit every four years, up to $50 in
-  United TravelBank cash, and $10 monthly in Instacart credit. The catch is
-  that IHG points are worth relatively little each, so the value only holds up
-  if you stay at IHG hotels often enough to burn the free night and the points
-  you earn.
+  The anniversary free night, good at properties costing up to 40,000 points
+  with the option to top off with points, is what carries the IHG One Rewards
+  Premier past its $99 annual fee, and a single decent stay usually covers the
+  cost outright. The earn structure is genuinely strong for a mid-tier hotel
+  card: 10 points per dollar at IHG properties, 5 points on travel, gas, and
+  dining, and 3 points on everything else, plus automatic Platinum Elite
+  status and a fourth reward night free on point stays. Chase currently ranks
+  it fifth on our Best Credit Card Signup Bonuses list with 140,000 points
+  after $3,000 in three months, though be aware that offer has swung hard this
+  year, peaking at 185,000 in June before being cut back to 140,000 in July.
+  The credits are real but scattered: up to $120 for Global Entry or TSA
+  PreCheck every four years, $50 in United TravelBank cash, and $10 monthly at
+  Instacart, all of which require enrollment or registration to see a dollar.
+  The stretch goals, 10,000 points and a $100 credit at $20,000 in spend and
+  Diamond Elite at $40,000, are for heavy spenders only, so judge this card on
+  the free night and the IHG earn rate alone.

--- a/data/cards/ihg-rewards-club-traveler-credit-card.yaml
+++ b/data/cards/ihg-rewards-club-traveler-credit-card.yaml
@@ -94,17 +94,18 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/ihg-rewards-club/t
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Traveler is the no-annual-fee way into the IHG program, and it earns
-  better than most free hotel cards: 5x at IHG properties, 3x across dining,
-  gas, utilities, and select streaming, and 2x on everything else, with no
-  foreign transaction fee. The 80,000-point bonus
-  after just $2,000 in three months is a low bar, though it is worth knowing
-  the offer ran as high as 125,000 points in June before falling back to
-  80,000 in July, so waiting for another spike is reasonable. What you give up
-  versus the $99 Premier is the anniversary free night and Platinum status:
-  here you get Silver Elite, which is the thinnest tier, and Gold only if you
-  charge $20,000 in a calendar year. The 4th night free on consecutive
-  four-night reward stays and $10 monthly in Instacart credit are the perks
-  most people will actually use. It is a sensible keeper card for occasional
-  IHG stays since it costs nothing to hold, but heavy IHG guests will do
-  better paying for the Premier.
+  For a card with no annual fee, the IHG Traveler earns unusually well: 5
+  points per dollar at IHG hotels, 3 points across a combined bucket of
+  dining, gas, utilities, and select streaming, and 2 points on everything
+  else, with no foreign transaction fee. The current 80,000-point bonus after
+  $2,000 in three months, plus another 10,000 for adding an authorized user,
+  is a low bar to clear, though it is worth knowing the offer hit 125,000 in
+  June before being cut back in July, so this is not the card's high-water
+  mark. Automatic Silver Elite status and a fourth reward night free on
+  consecutive four-night point stays are the ongoing perks that matter, and
+  both cost you nothing to hold. The tradeoff versus the Premier version is
+  the missing anniversary free night, which is the single benefit that usually
+  justifies paying a fee on an IHG card. Take this one if you stay at IHG
+  occasionally and want the earn rate without an annual commitment, and note
+  the 10,000 anniversary points require $10,000 of spend, so most cardholders
+  will never see them.

--- a/data/cards/ihg-rewards-premier-business.yaml
+++ b/data/cards/ihg-rewards-premier-business.yaml
@@ -87,14 +87,17 @@ apply_link: https://creditcards.chase.com/business-credit-cards/IHG/business-pre
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The IHG One Rewards Premier Business card from Chase offers a compelling
-  140,000-point signup bonus after spending $4,000 in the first three months,
-  plus an additional 10,000 points for adding an employee card. This makes it
-  a strong contender for those who frequently stay at IHG properties,
-  especially with the up to 26x points per dollar spent at IHG hotels. The
-  card also provides valuable perks like an annual free night award at
-  properties costing up to 40,000 points and automatic Platinum Elite status.
-  However, the $99 annual fee and the need to spend $20,000 annually to earn
-  10,000 bonus points and a $100 statement credit might not suit everyone. If
-  you can leverage the 4th Reward Night Free benefit and maximize your stays
-  at IHG hotels, this card could be a worthwhile addition to your wallet.
+  The business version of the IHG Premier keeps the anniversary free night
+  valid at properties up to 40,000 points, which alone tends to cover the $99
+  annual fee if you stay at IHG even once a year. Earn rates are the same
+  strong setup as the personal card with a business tilt: 10 points per dollar
+  at IHG properties, 5 points on travel, gas, dining, and office supply
+  stores, and 3 points on everything else, with no foreign transaction fee.
+  The 140,000-point bonus after $4,000 in three months has it ranked eighth on
+  our Best Credit Card Signup Bonuses list, though it is worth knowing that
+  offer reached 200,000 points in June before being pulled back to 140,000 in
+  July. Automatic Platinum Elite status, a fourth reward night free on point
+  stays, and up to $120 for Global Entry, TSA PreCheck, or NEXUS every four
+  years round out the ongoing value. The main catch is that IHG points are
+  worth less than most transferable currencies, so the free night and elite
+  status carry this card more than the raw point totals suggest.

--- a/data/cards/intuit-business.yaml
+++ b/data/cards/intuit-business.yaml
@@ -53,15 +53,17 @@ benefits:
     frequency: "one_time"
     category: "other"
 our_take: >
-  The reason to carry this card is the flat 2% back on everything, which is a
-  strong no-annual-fee floor for a business card and means you never have to
-  think about categories. If you run QuickBooks, TurboTax, or Mailchimp, the
-  5% back on Intuit products and services is a real discount on software you
-  are already buying, though it excludes transactional charges like merchant
-  services fees. The $300 bonus after $3,000 in three months is modest but
-  easy to clear, and unlimited free employee cards with their own limits and
-  controls plus automatic transaction and receipt sync into QuickBooks make
-  the bookkeeping side genuinely less work. The clear drawback is the foreign
-  transaction fee, so keep it home for any spending abroad. The APR also runs
-  as high as 35.24%, which makes this a card to pay in full rather than carry
-  a balance on.
+  If your business already runs on QuickBooks, this card's real selling point
+  is not the rewards but the plumbing: transactions and captured receipts flow
+  straight into QuickBooks without a separate bank feed or import, which
+  removes a recurring bookkeeping chore. The earn rate is respectable for a
+  no-annual-fee business card at 2% back on everything, rising to 5% on Intuit
+  products and services like QuickBooks, TurboTax, and Mailchimp, though that
+  5% applies only to Intuit purchases and excludes transactional fees such as
+  merchant services. There is a $300 bonus after $3,000 in three months, plus
+  unlimited free employee cards with their own limits and category controls.
+  Two honest catches: this card charges foreign transaction fees, so it is a
+  poor choice for any business buying abroad, and the APR range runs from
+  14.24% to 35.24%, meaning a weaker credit profile can land at a punishing
+  rate. Carry it for the flat 2% and the accounting integration, not for a
+  balance.

--- a/data/cards/jetblue-business-card.yaml
+++ b/data/cards/jetblue-business-card.yaml
@@ -39,18 +39,20 @@ apr:
     min: 19.49
     max: 29.49
 our_take: >
-  If your business books JetBlue regularly, 6x points on JetBlue purchases
-  plus a free first checked bag for you and up to three companions is the core
-  case for the $99 annual fee, and one round trip of checked bags roughly
-  covers it. The $100 JetBlue Vacations statement credit each year and 5,000
-  anniversary points chip away at the rest of the fee, and there is no foreign
-  transaction fee. The signup bonus is 50,000 points after $4,000 in three
-  months, down from 60,000 in May, so this is not the card's best-ever offer.
-  Outside of JetBlue, the earn rates are ordinary: 2x on dining and office
-  supplies and 1x on everything else, which is not competitive for general
-  business spend. Mosaic status is technically available but requires $50,000
-  of purchases in a calendar year, so treat it as a stretch goal rather than a
-  reason to apply.
+  The JetBlue Business earns 6 points per dollar on JetBlue purchases and
+  comes with a free first checked bag for you and up to three companions,
+  which for a two-person trip usually pays back the $99 annual fee in a single
+  round trip. The rest of the earn chart is modest, at 2 points on dining and
+  office supplies and 1 point everywhere else, so this is a card to pull out
+  for JetBlue flights rather than general business spend. The current
+  50,000-point bonus after $4,000 in three months was trimmed from 60,000 back
+  in May, so you are applying at a weaker offer than the card carried earlier
+  this year. Ongoing value comes from a $100 JetBlue Vacations statement
+  credit each year, 5,000 anniversary points, 10% of your points back after
+  you redeem and fly, and 50% off inflight food, drinks, and Wi-Fi. Mosaic
+  status is technically available but requires $50,000 in purchases per
+  calendar year, which is out of reach for most small businesses, so budget
+  for the fee against the bag fees and the annual credit instead.
 benefits:
   - name: "Anniversary Points Bonus"
     value: 5000

--- a/data/cards/jetblue-card.yaml
+++ b/data/cards/jetblue-card.yaml
@@ -41,17 +41,18 @@ apr:
     min: 19.49
     max: 29.49
 our_take: >
-  The no-annual-fee JetBlue card is a light touch: 3x points on JetBlue
-  purchases, 2x on dining and groceries, and 1x on everything else, with no
-  foreign transaction fee and 12 months of 0% intro APR on balance transfers.
-  That combination makes it a reasonable keeper for occasional JetBlue flyers
-  who do not want to pay for the airline's better cards. Just size up the
-  tradeoffs before applying: the signup bonus is only 10,000 points after
-  $1,000 in three months, and the card skips the checked bag benefit and
-  anniversary points that make the $99 versions worth their fee. The 50%
-  discount on inflight food, drinks, and Wi-Fi is the lone ongoing perk. If
-  you fly JetBlue more than a couple of times a year, compare it against the
-  Plus version before settling here.
+  The no-fee JetBlue card is the entry point to TrueBlue: 3 points per dollar
+  on JetBlue purchases, 2 points on dining and groceries, and 1 point on
+  everything else, with no foreign transaction fee. It sits at number 16 on
+  our Best Airline Credit Cards list, which is a fair reflection of what it
+  is, a light-duty card for occasional JetBlue flyers who do not want to pay
+  for the privilege. The 12 months of 0% intro APR on balance transfers is a
+  genuine secondary use if you are moving debt, though there is no intro rate
+  on purchases. Be clear about what you give up by not paying a fee: there is
+  no free checked bag, no anniversary points, and no annual travel credit, and
+  the 10,000-point bonus after $1,000 in spend is small. If you fly JetBlue
+  more than a couple of times a year, the Plus version's free bag alone will
+  outrun this card's savings on the annual fee.
 benefits:
   - name: "50% Off Inflight Purchases"
     value: 50

--- a/data/cards/jetblue-plus-card.yaml
+++ b/data/cards/jetblue-plus-card.yaml
@@ -10,19 +10,21 @@ foreign_transaction_fee: false
 network: "mastercard"
 reward_type: "points"
 our_take: >
-  The Plus is the strongest of JetBlue's cards for the money and tops our Best
-  Airline Credit Cards list: 6x points on JetBlue purchases, a free first
-  checked bag for you and up to three companions, and 5,000 anniversary points
-  every year against a $99 annual fee. The bonus is currently 70,000 points
-  after just $1,000 of spend in three months, back up in August after dipping
-  to 60,000 in May, and that spend requirement is one of the easiest around
-  for a bonus this size. A $100 JetBlue Vacations statement credit each year,
-  a 10% points rebate on award flights you fly, and no foreign transaction fee
-  make the fee easy to justify with even a couple of JetBlue trips. The
-  weakness is everyday earning: 2x on dining and groceries and 1x on
-  everything else means this card should not carry your general spending.
-  TrueBlue points are also only useful for JetBlue and its partners, so the
-  whole case rests on flying the airline.
+  The free first checked bag for you and up to three traveling companions is
+  what makes the JetBlue Plus worth its $99 fee, since a single round trip for
+  two typically covers the cost and anything beyond that is profit. It also
+  earns 6 points per dollar on JetBlue purchases, 2 points on dining and
+  groceries, and 1 point on everything else, and it tops our Best Airline
+  Credit Cards list at number two with a Best Overall badge. The signup bonus
+  is currently 70,000 points after just $1,000 in three months, which is an
+  unusually low spend requirement, and the offer recently moved back up from
+  60,000 in August, so this is a good moment to apply rather than a trough.
+  Ongoing perks stack up sensibly: 5,000 anniversary points, a $100 JetBlue
+  Vacations statement credit each year, 10% of your points back after award
+  travel, and 50% off inflight purchases, with no foreign transaction fee. The
+  honest limit is that TrueBlue points are only useful on JetBlue and its
+  partners, so if the airline does not serve your home airport well, none of
+  this matters.
 tags:
   - travel
   - airline

--- a/data/cards/jetblue-premier-card.yaml
+++ b/data/cards/jetblue-premier-card.yaml
@@ -42,21 +42,23 @@ apr:
     min: 19.49
     max: 29.49
 our_take: >
-  The Premier only makes sense if you fly JetBlue often enough to use its
-  credits, because the $499 annual fee is steep and the offsets are specific:
-  up to $300 a year in statement credits on TrueBlue Travel bookings like
-  hotels, car rentals, and cruises, 5,000 anniversary points, and a $120
-  Global Entry or TSA PreCheck credit every four years. Lounge access is the
-  real upgrade over the $99 Plus, combining JetBlue BlueHouse lounges for
-  cardmembers on eligible fares with a Priority Pass membership covering more
-  than 1,800 lounges. Earning is unchanged from the cheaper JetBlue cards at
-  6x on JetBlue and TrueBlue Travel purchases, 2x on dining and groceries, and
-  1x on everything else, so the fee buys perks, not better rewards. The
-  90,000-point signup bonus after $5,000 in three months was cut from 100,000
-  in early August, and the headline companion pass credits require $15,000 of
-  spend for the first $500 and $75,000 for the additional $1,500. Run the math
-  on the $300 travel credit and lounge visits honestly before committing; if
-  you would not clear those, the Plus does most of the job for $400 less.
+  At $499 a year, the JetBlue Premier is asking you to prepay for benefits you
+  must actively use, and the math only works for frequent JetBlue flyers. The
+  credits are the core of it: up to $300 in statement credits on TrueBlue
+  Travel purchases like hotels, car rentals, and cruises each calendar year,
+  plus up to $120 for Global Entry or TSA PreCheck every four years, which
+  together offset well over half the fee if you book that travel through
+  JetBlue. On top of that you get BlueHouse lounge access with eligible fares,
+  Priority Pass, a free first checked bag for you and up to three companions,
+  a 15% points rebate on award flights, and an annual 25-tile bonus toward
+  Mosaic. Earn rates are unchanged from the cheaper cards at 6 points per
+  dollar on JetBlue and TrueBlue Travel, 2 points on dining and groceries, and
+  1 point elsewhere, so you are not paying extra for a better points engine.
+  The companion pass credits look generous at up to $500, but they require
+  $15,000 in calendar-year spend, with the larger $1,500 tier needing $75,000,
+  and the signup bonus was cut from 100,000 to 90,000 points in August, so
+  evaluate this card on the $300 travel credit and lounge access rather than
+  the headline perks.
 benefits:
   - name: "TrueBlue Travel Statement Credits"
     value: 300

--- a/data/cards/kroger-rewards-world-elite-mastercard.yaml
+++ b/data/cards/kroger-rewards-world-elite-mastercard.yaml
@@ -76,16 +76,17 @@ benefits:
     description: "Complimentary Kroger Boost Essential membership, which includes free grocery delivery on qualifying orders and doubled fuel points."
     category: "shopping"
 our_take: >
-  This card is closed to new applicants, so it is only relevant if you already
-  hold one. For existing cardholders it still earns respectably at Kroger
-  family stores: 5% back on mobile wallet and Kroger Pay purchases, which only
-  applies when you actually pay through a mobile wallet or Kroger Pay rather
-  than swiping the card, capped at $3,000 of spend per calendar year before
-  dropping to 1%. Purchases made inside Kroger, Harris Teeter, Ralphs, Fred
-  Meyer, King Soopers, and the other family banners earn 2%, fuel centers
-  excluded, and everything outside that ecosystem earns just 1%, which is the
-  card's true base rate. The complimentary Boost Essential membership and an
-  extra 5 cents per gallon at Kroger fuel centers, rising to 25 cents after
-  $6,000 of annual spend, are worth keeping if you shop there weekly. Since it
-  costs nothing to hold, there is no urgency to close it, but a general
-  grocery card will earn more on the rest of your spending.
+  This card is no longer accepting applications, so it is worth understanding
+  only if you already hold one. Its best rate was 5% back on mobile wallet and
+  Kroger Pay purchases, which earned that rate only when you actually paid
+  through a mobile wallet and was capped at $3,000 of calendar-year spend
+  before dropping to 1%. Purchases made inside Kroger Family of Companies
+  stores, including Harris Teeter, Ralphs, Fred Meyer, and the other banners,
+  earned 2%, fuel centers excluded, and everything else earned a flat 1%,
+  which is the card's true base rate. The fuel discount and complimentary
+  Boost Essential membership are still useful if you shop these stores weekly,
+  but there is no annual fee to justify keeping it open beyond that. If you
+  are shopping for a replacement, the Blue Cash Preferred pays 6% at U.S.
+  supermarkets on the first $6,000 a year, or the U.S. Bank Cash+ keeps the
+  rewards with the same issuer through two 5% categories you choose each
+  quarter with no annual fee.

--- a/data/cards/marriott-bonvoy-bevy-american-express.yaml
+++ b/data/cards/marriott-bonvoy-bevy-american-express.yaml
@@ -7,20 +7,21 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Bevy's pitch is a mid-tier Marriott card that also earns well away from
-  hotels: 4x points at restaurants worldwide and U.S. supermarkets on up to
-  $15,000 of combined spend each year, then 2x, with a flat 2x on everything
-  else and 6x when you pay at hotels participating in Marriott Bonvoy. The
-  current welcome offer is 125,000 points plus a $150 statement credit after
-  $5,000 in 6 months, recently trimmed from 135,000 and set to end September
-  30, 2026, so the bonus has been moving around a lot this year. Against that
-  sits a $250 annual fee, and the recurring perks are mostly status rather
-  than cash: Gold Elite, 15 Elite Night Credits, and 1,000 bonus points per
-  paid stay booked direct. The annual Free Night Award only arrives after
-  $15,000 of spend in a calendar year, and it caps at 50,000 points, so it is
-  not automatic value. This works best if you stay with Marriott a few times a
-  year and will actually put grocery and dining spend on the card, not if you
-  want the fee covered by credits.
+  The Bevy's distinguishing feature is its everyday earn rate: 4 points per
+  dollar at restaurants worldwide and U.S. supermarkets on up to $15,000 of
+  combined annual spend, then 2 points, which is stronger outside of hotels
+  than most co-branded Marriott cards. At Marriott Bonvoy properties it earns
+  6 points per dollar, and everything else earns 2 points, all with no foreign
+  transaction fee. The current offer is 125,000 points after $5,000 in six
+  months plus a $150 statement credit, though it expires on September 30,
+  2026, and this bonus has been unusually volatile, swinging from 175,000 down
+  to 85,000 in May, back to 135,000 in June, and settling at 125,000 in
+  August. Complimentary Gold Elite status and 15 Elite Night Credits each year
+  help toward higher status, but the free night award only arrives after
+  $15,000 in calendar-year spend, so the $250 annual fee is not automatically
+  covered the way it is on cards with an unconditional free night. Judge this
+  one on whether you will actually put dining and grocery spend on it, because
+  that is where the fee earns back.
 annual_fee: 250
 reward_type: "points"
 rewards:

--- a/data/cards/marriott-bonvoy-bold-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-bold-credit-card.yaml
@@ -84,19 +84,20 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/marriott-bonvoy/bo
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Bold is the no annual fee entry point to Marriott Bonvoy, earning 3x
-  points on stays at Marriott properties and 2x on a fairly wide everyday mix:
-  groceries, select streaming, internet and cable, phone service, and
-  rideshare. Automatic Silver Elite status and 5 Elite Night Credits a year
-  cost you nothing to hold, and the card adds real travel coverage for a free
-  product, including trip delay reimbursement up to $500 per ticket and lost
-  luggage protection up to $3,000. The welcome offer was recently cut from
-  60,000 to 45,000 points after $1,000 of spend in 3 months, which is still an
-  easy threshold but a weaker starting point than it was. The tradeoff is that
-  everything here is modest: 1x on unbounded spend, Silver is the lowest
-  useful Bonvoy tier, and there is no annual free night, which is the benefit
-  that justifies the fee on Marriott's paid cards. Take it as a cheap way to
-  hold Bonvoy status and earn on Marriott stays, not as a card you lead with.
+  The Bonvoy Bold's appeal is that it costs nothing to hold while still giving
+  you automatic Silver Elite status and 5 Elite Night Credits a year toward
+  higher Marriott status, which is a reasonable trade for a card you keep in a
+  drawer. Earn rates are modest: 3 points per dollar at Marriott Bonvoy
+  hotels, 2 points on groceries, select streaming, internet and cable, phone
+  service, and rideshare, and 1 point on everything else, with no foreign
+  transaction fee. The 45,000-point bonus after just $1,000 in three months is
+  easy to hit, though it was trimmed from 60,000 in August, so this is a
+  weaker entry point than the card offered earlier in the year. The travel
+  protections are the quiet strength here for a no-fee product, including up
+  to $500 per ticket in trip delay reimbursement, baggage delay coverage, and
+  up to $3,000 in lost luggage reimbursement. Just do not expect this card to
+  move you meaningfully up the Bonvoy ladder: the elite night credits help,
+  but Silver status carries little practical benefit on its own.
 signup_bonus:
   value: 45000
   type: "points"

--- a/data/cards/marriott-bonvoy-boundless-credit-card.yaml
+++ b/data/cards/marriott-bonvoy-boundless-credit-card.yaml
@@ -88,16 +88,16 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/marriott-bonvoy/bo
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Boundless earns its $95 annual fee mainly through one benefit: a Free
-  Night Award every year good for redemptions up to 35,000 points, which a
-  single decent Marriott stay can outrun. Around that you get 6x on Marriott
-  stays, 3x on groceries, gas, and dining up to a combined $6,000 a year and
-  2x after, 2x on other travel and everything else, plus 15 Elite Night
-  Credits and automatic Silver Elite. The current welcome offer is 4 Free
-  Night Awards, each valid up to 50,000 points a night, after $3,000 in the
-  first 3 months, which is the most valuable thing about the card if you have
-  Marriott stays planned. The catch is that the 35,000 point ceiling on the
-  annual night is low for peak dates and popular properties, and the $100 in
-  airline credits comes in $50 halves that each require $250 of airline spend,
-  so it is not automatic. Worth holding if you stay with Marriott at least
-  once a year at a property the free night can actually cover.
+  The Boundless earns its $95 annual fee mainly through one predictable perk:
+  a free night award each year good for a redemption up to 35,000 points,
+  which a single well-chosen stay can cover on its own. The current welcome
+  offer is unusually generous too, with 4 Free Night Awards worth up to 50,000
+  points each after $3,000 in purchases within 3 months, and you also get 15
+  elite night credits and automatic Silver Elite. The earn rates are where it
+  thins out: 6 points per dollar applies only at Marriott Bonvoy properties,
+  and the 3x on groceries, gas, and dining shares a combined $6,000 annual cap
+  before dropping to 2x, which is the same rate everything else earns. The
+  $100 in annual airline statement credits comes in two $50 halves and each
+  requires $250 of airline spend first, so it is not automatic money. This is
+  a card to hold for the free night and the Marriott rate, not to put your
+  everyday spending on.

--- a/data/cards/marriott-bonvoy-brilliant-american-express.yaml
+++ b/data/cards/marriott-bonvoy-brilliant-american-express.yaml
@@ -7,21 +7,20 @@ apply_link: https://www.americanexpress.com/us/credit-cards/card/marriott-bonvoy
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Brilliant is the card you carry for Marriott Bonvoy Platinum Elite
-  status without staying 50 nights, and the annual Free Night Award is
-  unusually generous at up to 85,000 points, enough to reach properties the
-  cheaper Bonvoy cards cannot. The welcome offer currently sits at 150,000
-  points after $6,000 in 6 months, up from 100,000 earlier this year. The $650
-  annual fee is the obstacle, and Amex has stacked credits to answer it: $25 a
-  month in dining credits worth $300 a year, a $100 property credit on stays
-  of two or more consecutive nights, Priority Pass lounge access, and a Global
-  Entry or TSA PreCheck credit every 4 years. Those only work if your spending
-  fits the shape, since the dining credit is monthly and expires unused, and
-  the property credit requires a qualifying two night Marriott stay. Earning
-  is fine but not the draw: 6x at Marriott properties, 3x at restaurants and
-  on flights booked directly with airlines, 2x on everything else. This makes
-  sense for a regular Marriott guest who will use the dining credit every
-  month; occasional guests should look at the cheaper Bonvoy cards.
+  The Brilliant is built around a free night award good for redemptions up to
+  85,000 points plus complimentary Marriott Bonvoy Platinum Elite status,
+  which is the highest-tier status you can get from a card in this family and
+  brings upgrades, late checkout, and lounge access. The welcome offer
+  currently sits at 150,000 points after $6,000 in purchases within 6 months,
+  up from 100,000 after Amex cut it from 200,000 earlier this year. The math
+  on the $650 annual fee hinges on credits you have to actually use: $25 a
+  month in dining statement credits, $100 toward a Marriott stay of two or
+  more consecutive nights, and Global Entry or TSA PreCheck once every 4
+  years. Outside of the 6 points per dollar at Marriott Bonvoy properties, the
+  earn structure is modest at 3x on restaurants and direct airline bookings
+  and 2x on everything else. If you stay with Marriott a few times a year and
+  will use the monthly dining credit, this works; if the credits sit unused,
+  the fee is hard to justify.
 annual_fee: 650
 reward_type: "points"
 rewards:

--- a/data/cards/marriott-bonvoy-business-american-express.yaml
+++ b/data/cards/marriott-bonvoy-business-american-express.yaml
@@ -78,18 +78,18 @@ benefits:
     frequency: "ongoing"
     category: "hotel"
 our_take: >
-  This is the most balanced Bonvoy card for a business that spends outside
-  hotels: 4x points at restaurants, U.S. gas stations, U.S. wireless
-  providers, and U.S. shipping providers, 2x on everything else, and 6x at
-  hotels participating in Marriott Bonvoy. The $125 annual fee is largely
-  answered by the Free Night Award each year after renewal, good for
-  redemptions up to 35,000 points, and a second one arrives if you put $60,000
-  through the card in a calendar year. Gold Elite status, 15 Elite Night
-  Credits, and a 7% discount on standard rate bookings made directly with
-  Marriott round it out. The welcome offer is tiered rather than a single hit:
-  75,000 points after $6,000 in purchases, then another 50,000 after $3,000
-  more, all within the first 6 months, so the full 125,000 takes $9,000 of
-  spend. The 35,000 point ceiling on the free night is the honest limit here,
-  since it will not cover peak dates at higher end properties, but for a
-  business with real gas, phone, and shipping spend the everyday categories
-  carry the card between stays.
+  For $125 a year this is the cheapest way to get Marriott Bonvoy Gold Elite
+  status plus a free night award good for redemptions up to 35,000 points, and
+  the welcome offer is substantial: 125,000 points total, structured as 75,000
+  after $6,000 in purchases and another 50,000 after $3,000 more within the
+  first 6 months. The category rates are genuinely useful for a small
+  business, with 4 points per dollar on restaurants worldwide, U.S. gas
+  stations, U.S. wireless service bought directly from providers, and U.S.
+  shipping, plus 2x on everything else. The 6 points per dollar rate only
+  applies at hotels participating in Marriott Bonvoy, so treat it as a stay
+  bonus rather than a travel rate. The second free night award sounds
+  appealing but requires $60,000 in purchases in a calendar year, which most
+  small businesses will not hit. The honest test is whether the annual free
+  night plus 15 elite night credits and the 7% room rate discount clear $125
+  for you, and for anyone who stays at Marriott even twice a year, they
+  usually do.

--- a/data/cards/my-best-buy-visa.yaml
+++ b/data/cards/my-best-buy-visa.yaml
@@ -44,17 +44,16 @@ benefits:
     category: "shopping"
 apply_link: https://www.citi.com/credit-cards/citi-best-buy-credit-cards
 our_take: >
-  If you buy electronics and appliances at Best Buy with any regularity, this
-  card pays 5% back there with no annual fee, and it earns outside the store
-  too: 3% on gas, 2% on dining and groceries, and 1% on everything else. New
-  cardmembers also get 10% back on the first day of purchases made within 14
-  days of opening, which is worth timing around a large planned buy. The
-  important caveat is what the rewards actually are: the 5% posts as My Best
-  Buy points worth roughly 2 cents each and redeems as Best Buy certificates,
-  not cash, so the value is locked to one retailer even though the gas and
-  grocery earning happens everywhere. The deferred interest financing on
-  larger Best Buy purchases is an alternative to earning rewards on that same
-  purchase, and deferred interest means the full back interest is charged if
-  any balance remains at the end of the promotional term. Sensible as a store
-  card if Best Buy is a regular stop, but a general 2% cash back card will
-  beat it everywhere else.
+  If you buy electronics and appliances regularly, 5% back at Best Buy in
+  store and on BestBuy.com is the reason to carry this, and it comes with no
+  annual fee. Read the fine print on those rewards, though: they post as My
+  Best Buy points worth roughly 2 cents each and redeem as Best Buy
+  certificates, not cash, so the value is locked inside the store. The
+  off-brand rates are respectable for a store-linked Visa at 3% on gas, 2% on
+  dining and groceries, and 1% on everything else, but none of them beat a
+  good flat-rate cash back card. The bigger catch is the deferred interest
+  financing option on qualifying Best Buy purchases: it is offered as an
+  alternative to earning rewards on the same purchase, and if the balance is
+  not cleared in the promotional window, deferred interest is an expensive
+  mistake. Take the 10% back on first-day purchases within 14 days of opening,
+  then use the card at Best Buy and little else.

--- a/data/cards/navy-federal-cash-rewards-plus.yaml
+++ b/data/cards/navy-federal-cash-rewards-plus.yaml
@@ -9,18 +9,19 @@ foreign_transaction_fee: false
 network: "visa"
 reward_type: "cashback"
 our_take: >
-  The cashRewards Plus pays a flat 2% on everything with no annual fee and no
-  foreign transaction fee, which puts it in the top group of no fee flat rate
-  cards and makes it usable abroad without a second card. Navy Federal's rates
-  are the quieter advantage: a regular APR of 14.15% to 18%, 1.99% intro APR
-  on balance transfers for 12 months, and no balance transfer fee at all, so
-  consolidating a balance here is unusually cheap. The welcome offer is $250
-  after $2,500 in the first 3 months, available on applications through
-  January 3, 2027. The catch is that you do not apply for this card directly:
-  it is issued on the cashRewards application only when you are approved for a
-  credit limit of $5,000 or more, and lower limits get the 1.5% version
-  instead. Navy Federal membership is also required, so this is a strong
-  everyday card only if you are eligible and approved at the higher tier.
+  The appeal here is simple: 2% cash back on everything with no annual fee and
+  no foreign transaction fee, which makes it a legitimate everyday catch-all
+  rather than a category card. The $250 bonus after $2,500 in purchases within
+  3 months is easy to hit, and the ongoing APR range of 14.15% to 18% is well
+  below what most rewards cards charge if you ever carry a balance. There is
+  one real condition to understand: the Plus version at 2% is issued only when
+  you are approved for a credit limit of $5,000 or more, and lower limits get
+  the standard cashRewards card at 1.5%, so the headline rate is not
+  guaranteed at application. For anyone moving debt, the 12 months at 1.99% on
+  balance transfers with no balance transfer fee is a rare combination, since
+  most issuers charge 3% to 5% up front. Beyond a rental car collision damage
+  waiver, there are no travel perks or credits, which is the tradeoff for a
+  card that just pays a flat rate cleanly.
 tags:
   - cashback
   - rewards

--- a/data/cards/navy-federal-cash-rewards-secured.yaml
+++ b/data/cards/navy-federal-cash-rewards-secured.yaml
@@ -32,16 +32,15 @@ benefits:
     category: "travel"
     enrollment_required: false
 our_take: >
-  This is a credit builder first and a rewards card second, and it is honest
-  about that: 1% back on everything, no annual fee, and a $200 minimum
-  security deposit. What sets it apart from most secured cards is the exit
-  path, since you can get a credit limit increase after 3 months without
-  adding to your deposit, and the account is reviewed monthly for an upgrade
-  to the unsecured cashRewards card starting at 6 months, with your deposit
-  returned when that happens. The APR is a flat 18%, which is high in absolute
-  terms but below where most secured cards sit, though you should still plan
-  to pay in full every month. The rewards are the weakest part: 1% will not
-  compete with anything you can get once your credit recovers, and there is no
-  signup bonus. Use it for the 6 to 12 months it takes to graduate, then move
-  to the unsecured version. Navy Federal membership is required to apply.
+  This is a credit-building card first and a rewards card a distant second: 1%
+  cash back on everything, no annual fee, and a flat 18% APR. What sets it
+  apart from most secured cards is the exit path, which is spelled out rather
+  than vague. You can be considered for a credit limit increase after 3 months
+  without adding to your deposit, and starting at 6 months the account is
+  reviewed monthly for an upgrade to the unsecured cashRewards card, with your
+  security deposit of at least $200 returned when that happens. The absence of
+  a foreign transaction fee is unusual at this tier and makes it usable on a
+  trip. Just be realistic about the earn rate: 1% is a placeholder, so the
+  goal is to use the card lightly, pay in full, and graduate off it rather
+  than settle in.
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards-secured.html

--- a/data/cards/navy-federal-cash-rewards.yaml
+++ b/data/cards/navy-federal-cash-rewards.yaml
@@ -41,16 +41,16 @@ benefits:
     category: "travel"
     enrollment_required: false
 our_take: >
-  The cashRewards is a simple flat rate card: 1.5% back on everything, no
-  annual fee, and no foreign transaction fee, which is a rarer combination
-  than it sounds on a no fee cash back card. The $250 bonus after $2,500 in 3
-  months is straightforward, and the rate structure is the real selling point,
-  with a regular APR range of 14.15% to 18% that runs well below what most
-  issuers charge. Navy Federal also charges no balance transfer fee and offers
-  1.99% intro APR on transfers for 12 months, so moving a balance here costs
-  almost nothing up front. The important detail is the tier: approvals with a
-  credit limit of $5,000 or more are issued as cashRewards Plus at 2%, so 1.5%
-  is the outcome for smaller limits rather than the headline. You need Navy
-  Federal membership to apply, and if you qualify, 1.5% is a fair floor but
-  not a reason to pass on a 2% card elsewhere.
+  A flat 1.5% cash back on everything with no annual fee and no foreign
+  transaction fee is a straightforward, low-maintenance setup, and the $250
+  bonus after $2,500 in purchases within 3 months pays for a lot of that first
+  year. The strongest feature is arguably not the rewards at all: 12 months at
+  1.99% on balance transfers with no balance transfer fee, which is unusual,
+  since most issuers take 3% to 5% of the transferred amount off the top. The
+  ongoing APR of 14.15% to 18% is also low for a rewards card. Worth knowing
+  before you apply: approved credit limits of $5,000 or more are issued as
+  cashRewards Plus instead, which earns 2%, so the version you end up with
+  depends on your approval. At 1.5% this is a fine default card but not a
+  category winner, and a rental car collision damage waiver is the only perk
+  of note.
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/cash-rewards.html

--- a/data/cards/navy-federal-flagship-rewards.yaml
+++ b/data/cards/navy-federal-flagship-rewards.yaml
@@ -8,20 +8,19 @@ annual_fee: 49
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Flagship packs premium style perks into a $49 annual fee, and the
-  standout is a statement credit covering an Amazon Prime annual membership
-  each year, worth $139, which alone more than covers the fee if you already
-  pay for Prime. Earning is solid and simple: 3x points on a broad travel
-  definition that includes airlines, hotels, car rentals, rideshare, parking,
-  tolls, museums, amusement parks, and golf, with 2x on everything else and no
-  foreign transaction fee. The welcome offer is 35,000 points, worth $350,
-  after $3,500 in the first 3 months, on applications through January 3, 2027.
-  Rates are the other quiet advantage, with a regular APR of 14.74% to 18% and
-  no balance transfer fees. The limits are worth naming: there is no lounge
-  access or annual travel credit here beyond the Global Entry or TSA PreCheck
-  credit every 4 years, and you need Navy Federal membership to apply at all.
-  For an eligible member who wants one card to cover travel and everyday
-  spend, the math is hard to argue with.
+  The Flagship pairs a $49 annual fee with a $139 annual statement credit
+  covering an Amazon Prime membership paid with the card, so the fee is more
+  than covered if you were buying Prime anyway. Earn rates are solid and
+  broadly defined: 3 points per dollar on travel that includes airlines,
+  hotels, car rentals, ride-sharing, parking, tolls, museums, amusement parks,
+  and golf courses, plus 2x on everything else, which is a strong floor for a
+  card at this price. The welcome offer is 35,000 points worth $350 after
+  $3,500 in purchases within 3 months, and there is a Global Entry or TSA
+  PreCheck credit of up to $120 once every 4 years. No foreign transaction
+  fee, travel accident insurance, and 24/7 emergency assistance round out a
+  genuinely travel-ready package. The limitation is scale rather than quality:
+  there is no lounge access and no hotel or airline status, so this is a value
+  travel card, not a competitor to premium $500-plus products.
 reward_type: "points"
 tags:
   - travel

--- a/data/cards/navy-federal-go-biz-rewards.yaml
+++ b/data/cards/navy-federal-go-biz-rewards.yaml
@@ -31,14 +31,13 @@ benefits:
     enrollment_required: false
 apply_link: https://www.navyfederal.org/services/business/credit-cards.html
 our_take: >
-  The GO BIZ Rewards is built around access rather than earn rate: no annual
-  fee, no foreign transaction fees, and cards for multiple employees on one
-  account at no extra cost, which is the practical reason most small
-  businesses would carry it. The rewards are the weak point, a flat 1 point
-  per dollar on everything with no bonus categories at all, so any business
-  with meaningful spend concentrated in one area will earn more elsewhere.
-  What it does have is a tight interest range, 16.65% to 18% regular APR,
-  which is unusually low for a business card if you occasionally carry a
-  balance. Purchase protection on eligible items rounds out a short benefits
-  list. Treat this as a Navy Federal member's simple, cheap company card, not
-  a rewards play.
+  GO BIZ Rewards is a basic business card rather than a rewards play: 1 point
+  per dollar on everything, no annual fee, and no foreign transaction fee. Its
+  practical value is in the account structure, since you can issue cards to
+  multiple employees on one account at no extra cost, which keeps spend
+  consolidated without paying per-card fees. The APR range of 16.65% to 18% is
+  low for a business card, so it is less punishing than most if a balance
+  occasionally rolls over. New purchase protection on eligible items is the
+  only meaningful benefit beyond that. There is no welcome bonus and no bonus
+  category, so if earning is your priority, put real spend elsewhere and keep
+  this as a no-cost card for employee expenses.

--- a/data/cards/navy-federal-go-rewards.yaml
+++ b/data/cards/navy-federal-go-rewards.yaml
@@ -40,14 +40,14 @@ benefits:
     enrollment_required: false
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/go-rewards.html
 our_take: >
-  Three points per dollar on dining is the reason to carry the GO REWARDS,
-  backed by 2 points on gas and a $0 annual fee, so a member who eats out
-  regularly earns without paying for the privilege. Navy Federal charges no
-  balance transfer fees and no foreign transaction fees here, which makes it a
-  reasonable card to take abroad or use to move a balance. The intro offer is
-  modest by market standards: 0.99% on purchases for 6 months rather than a
-  true 0% window, though the 13.49% to 18% regular APR is low enough that the
-  gap matters less than it would at another issuer. Everything outside dining
-  and gas earns just 1 point per dollar, so this works better as a category
-  card than as your only one. A rental car collision damage waiver when you
-  pay with the card is the main travel extra.
+  GO REWARDS is a no-annual-fee card built around one category: 3 points per
+  dollar on dining, with 2x on gas and 1x on everything else. If you eat out
+  often and want a card that costs nothing to hold, that is a reasonable
+  trade, though the 1x base rate means you should not run general spending
+  through it. The rate that stands out is the APR: 13.49% to 18% ongoing is
+  meaningfully below the market, and there is an introductory 0.99% on
+  purchases for the first 6 months if you need to finance something in the
+  short term. Navy Federal also charges no balance transfer fees on this card,
+  which is worth more than it sounds when most issuers take 3% to 5%. There is
+  no welcome bonus, so the case for this card rests entirely on the dining
+  rate and the low ongoing interest rather than any upfront payoff.

--- a/data/cards/navy-federal-more-rewards-american-express.yaml
+++ b/data/cards/navy-federal-more-rewards-american-express.yaml
@@ -9,17 +9,18 @@ foreign_transaction_fee: false
 network: "amex"
 reward_type: "points"
 our_take: >
-  The More Rewards Amex earns 3 points per dollar across four of the most
-  common spending categories, dining including food delivery, groceries, gas,
-  and transit, and charges no annual fee to do it. That breadth is what
-  separates it from most no-fee cards, which usually make you pick one or two
-  categories. There is a 20,000 point signup bonus worth $200 after $2,000 in
-  purchases within 3 months, available on applications through 1/3/2027. The
-  catches are ordinary: everything outside those four categories earns 1 point
-  per dollar, and while there is no foreign transaction fee, the Amex network
-  is accepted less widely overseas than Visa or Mastercard. Navy Federal
-  membership is the real gate, but if you have it, this is a straightforward
-  core earner with a 14.15% to 18% regular APR behind it.
+  This is the strongest everyday earner in Navy Federal's lineup for a card
+  that costs nothing to hold: 3 points per dollar on dining including food
+  delivery, groceries, gas, and transit, which covers most of a typical
+  household budget. The welcome offer is 20,000 points worth $200 after $2,000
+  in purchases within 3 months, a low bar for that return, and there is no
+  foreign transaction fee. The gap is the 1 point per dollar base rate, so
+  anything outside those four categories belongs on a flat-rate card, and
+  there are no annual credits or statement perks to fall back on. The ongoing
+  APR of 14.15% to 18% is unusually low for a rewards card, and Navy Federal
+  charges no balance transfer fees here. Car rental discounts of up to 25%
+  with loss and damage insurance are a small but real extra. Pair it with a 2%
+  catch-all and it does a lot of work for free.
 tags:
   - rewards
   - dining

--- a/data/cards/navy-federal-platinum.yaml
+++ b/data/cards/navy-federal-platinum.yaml
@@ -33,15 +33,16 @@ benefits:
     enrollment_required: false
 apply_link: https://www.navyfederal.org/loans-cards/credit-cards/platinum.html
 our_take: >
-  The Platinum is a debt payoff card and nothing more: 0.99% intro APR on
-  balance transfers for 12 months, no annual fee, and no balance transfer fee
-  at all, which is where most transfer cards claw back 3% to 5% up front. The
-  bigger draw may be what happens after the promo, a 10.24% to 18% regular APR
-  that sits far below what most issuers charge, so a balance that outlives the
-  intro window is not punished the way it would be elsewhere. Be clear on the
-  tradeoff: this card earns no rewards whatsoever, so there is no reason to
-  put ongoing spending on it. A collision damage waiver on rentals of 15 days
-  or less and 24/7 travel and emergency assistance are the only extras worth
-  naming. Open it to consolidate debt cheaply, then keep it for the low rate
-  rather than the perks.
+  The Platinum is a debt payoff tool, not a rewards card, and it is unusually
+  well built for that one job. You get 12 months at 0.99% on balance transfers
+  with no balance transfer fee at all, which matters because most issuers
+  charge 3% to 5% up front and quietly erase part of the savings before you
+  make a payment. Just as important, the ongoing APR of 10.24% to 18% is low
+  enough that you are not falling off a cliff when the promotional window
+  closes, which is the usual failure point with 0% intro offers. There is no
+  annual fee and no foreign transaction fee, and a rental car collision damage
+  waiver for rentals of 15 days or less plus 24/7 travel and emergency
+  assistance are the only extras. Be clear about what you are getting: this
+  card earns nothing, so open it with a payoff plan and keep a rewards card
+  for spending.
 

--- a/data/cards/nfl-extra-points-american-express-card.yaml
+++ b/data/cards/nfl-extra-points-american-express-card.yaml
@@ -53,19 +53,19 @@ apr:
     min: 17.49
     max: 31.49
 our_take: >
-  This is a fan card first and a rewards card second. The 3% back only applies
-  to NFL spending, meaning NFLShop.com, stadium purchases and game tickets, so
-  unless you buy season tickets it is a small slice of a year's spending. The
-  2% tier is the part that could actually carry the card, covering restaurants,
-  groceries, food delivery, sporting goods and gyms with no cap and no annual
-  fee. That is a reasonable everyday rate, but plenty of no-fee cards pay 2% on
-  everything, and this one drops to 1% outside its categories while charging a
-  3% foreign transaction fee. Points are worth a flat 1 cent each toward a
-  statement credit and expire 5 years after they post. The standing 25% off
-  NFLShop.com is worth more than the 3% category to most fans, and the $100
-  bonus after $500 in non-NFL spend within 90 days is easy to clear. Take it
-  for the team art and the merchandise discount, not because it beats a flat
-  2% card.
+  The NFL Extra Points card is built for fans who spend on their team: 3% back
+  at NFLShop.com, on NFL stadium purchases, and on game tickets bought through
+  team ticket offices, Ticketmaster, SeatGeek or Sports Illustrated Tickets,
+  plus a standing 25% off NFLShop.com when you pay with the card and use code
+  EXTRAPOINTS4. Away from the league it is decent rather than special, with 2%
+  on dining, groceries, sporting goods and gym memberships and 1% on
+  everything else, all for no annual fee. The $100 statement credit after $500
+  in the first 90 days is easy to clear, but read the fine print: NFL
+  purchases do not count toward that spend requirement. Points redeem at 1
+  cent apiece and expire five years after they post, and the card charges a
+  foreign transaction fee, so it should stay home when you travel. This one
+  pays off if you genuinely buy team merchandise and tickets every season;
+  casual fans will earn more with a flat-rate cash back card.
 benefits:
   - name: "25% Off NFLShop.com"
     value: 25

--- a/data/cards/nhl-discover-it.yaml
+++ b/data/cards/nhl-discover-it.yaml
@@ -36,14 +36,16 @@ apply_link: https://www.discover.com/credit-cards/cash-back/nhl-card.html
 foreign_transaction_fee: false
 network: "discover"
 our_take: >
-  This is the familiar Discover it cash back structure in NHL packaging: 5%
-  back on rotating quarterly categories on up to $1,500 in spend per quarter,
-  then 1%, with no annual fee. You have to activate each quarter, and the Q3
-  2026 lineup covers gas, EV charging, transit, airlines, and drugstores, a
-  broad slate for anyone who commutes or travels. A 15 month 0% intro APR on
-  both purchases and balance transfers gives it a second use if you have
-  something to finance. The limits are the usual ones: the bonus is capped at
-  $75 per quarter, everything outside the rotating category earns 1%, and
-  Discover acceptance is thinner than Visa or Mastercard, though there is no
-  foreign transaction fee. Choose it over a flat-rate card only if you will
-  reliably remember to activate.
+  This is the standard Discover it rotating-category card with NHL team
+  branding on the front: 5% back on up to $1,500 in purchases each quarter you
+  activate, which for Q3 2026 covers gas, EV charging, transit, airlines and
+  drugstores, then 1% once you pass the cap. It also carries 15 months of 0%
+  intro APR on both purchases and balance transfers with no annual fee and no
+  foreign transaction fee, a combination that makes it usable as a payoff card
+  rather than just an earner. The tradeoffs are the familiar rotating-card
+  ones: you have to remember to activate every quarter, the cap limits bonus
+  earnings to $75 per quarter, and everything outside the featured categories
+  pays a flat 1%. The team art is the only thing the NHL branding actually
+  adds, so pick it on looks, not on value. Use it hard for the quarters whose
+  categories match your spending and keep a stronger everyday card for the
+  rest.

--- a/data/cards/paypal-cashback-mastercard.yaml
+++ b/data/cards/paypal-cashback-mastercard.yaml
@@ -26,13 +26,12 @@ apply_link: https://www.paypal.com/us/digital-wallet/manage-money/paypal-cashbac
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The headline 3% applies only when you actually check out through PayPal,
-  online or with the in-store QR code, so it rewards a specific habit rather
-  than a whole category. Anywhere PayPal is not used the card earns 1.5% back,
-  a fair but unremarkable base rate for a card with no annual fee. If a large
-  share of your online spending already routes through PayPal, that pairing is
-  easy to justify. The drawbacks are real: it charges foreign transaction
-  fees, so leave it home when you travel, and the regular APR runs 18.49% to
-  33.24%, high enough that carrying a balance would wipe out a year of
-  rewards. There is no signup bonus, so all of the value here sits in the
-  ongoing earn rate.
+  The headline 3% on this card applies only when you check out through PayPal,
+  online or with the in-store QR code, so its value tracks almost entirely
+  with how much of your shopping already runs through that wallet. What keeps
+  it from being a one-trick card is the 1.5% it pays everywhere else, a fair
+  floor for a card with no annual fee. There is no signup bonus and no intro
+  APR, so nothing sweetens the first year, and the regular APR runs from
+  18.49% to 33.24%. It also charges a foreign transaction fee, which takes it
+  out of the running for travel. If PayPal is your default checkout, the 3% is
+  worth having; if it is not, a straightforward 2% card beats this outright.

--- a/data/cards/penfed-pathfinder-rewards.yaml
+++ b/data/cards/penfed-pathfinder-rewards.yaml
@@ -52,19 +52,15 @@ benefits:
     category: "lounge"
     enrollment_required: true
 our_take: >
-  The PenFed Pathfinder Rewards Visa Signature was built around a fee waiver
-  that is going away. PenFed is notifying cardholders that the $95 annual fee
-  is no longer eligible to be waived as of September 28, 2026, so Honors
-  Advantage members, meaning current or former military and Access America
-  checking customers, lose the perk that made this an effectively free travel
-  card. Judge it on the $95. The $100 annual domestic airline incidental
-  credit covers most of that by itself, and a Global Entry or TSA PreCheck
-  application credit every four years plus a Priority Pass membership fill out
-  a package that still holds up at this price, though lounge visits carry
-  per-visit fees. Honors Advantage members do keep the better earn rates, 4x
-  on travel and 3x on dining against 3x and 2x for everyone else, alongside
-  1.5x on everything else and no foreign transaction fees. The 50,000-point
-  bonus after $3,000 in the first 90 days is a fair start. Points redeem at
-  roughly fixed value through a modest catalog with no transfer partners, so
-  this is not a flexible-points powerhouse. It is a reasonable mid-fee travel
-  card now rather than the free-money play it used to be.
+  The Pathfinder fits a lot behind a $95 annual fee: a 50,000-point bonus
+  after $3,000 in three months, up to $100 a year in credits for airline
+  incidental fees, a Global Entry or TSA PreCheck reimbursement once every
+  four years, and a Priority Pass membership. Earning is respectable too, at
+  4x on travel, 3x on dining and 1.5x on everything else, with no foreign
+  transaction fee and a flat 17.99% APR. The catch is that those top rates
+  require PenFed Honors Advantage status, meaning current or former military
+  or a PenFed Access America checking account; without it you earn 3x on
+  travel and 2x on dining. The Priority Pass is also the membership tier that
+  charges per visit, so treat it as discounted lounge access, not free entry.
+  If you qualify for Honors Advantage and actually use the airline credit, the
+  fee covers itself easily; if you do not, the case for it gets much thinner.

--- a/data/cards/penfed-power-cash-rewards.yaml
+++ b/data/cards/penfed-power-cash-rewards.yaml
@@ -30,14 +30,14 @@ apr:
     max: 17.99
 benefits: []
 our_take: >
-  This is a flat-rate cash back card whose real rate depends on who you are:
-  2% on everything for PenFed Honors Advantage members, meaning current or
-  former military or holders of an Access America checking account, and 1.5%
-  for everyone else. At 2% with no annual fee it is a legitimate everyday
-  card; at 1.5% it trails most of the no-fee field, so your membership status
-  is essentially the whole decision. A $100 bonus after $1,500 in purchases
-  within 3 months and 12 months of 0% intro APR on balance transfers give it
-  some early utility, and there are no foreign transaction fees. What you do
-  not get is a benefits package of any kind, and the rate resets to a flat
-  17.99% once the transfer window closes. Simple and cheap to hold, but only
-  really worth it at the higher tier.
+  Power Cash Rewards is a flat 2% cash back card with no annual fee and no
+  foreign transaction fee, which puts it among the simplest everyday earners
+  you can carry abroad without a surcharge. The important asterisk is that the
+  2% depends on PenFed Honors Advantage status, meaning current or former
+  military or a PenFed Access America checking account; without one of those
+  the rate drops to 1.5% and the card stops standing out. A $100 bonus after
+  $1,500 in the first three months is modest but reachable, and 12 months of
+  0% intro APR on balance transfers gives it a short second life as a payoff
+  card. That intro rate does not extend to purchases, and the ongoing APR is a
+  flat 17.99%. There are no other benefits attached, so you carry this one for
+  the rate itself and nothing more.

--- a/data/cards/playstation-visa.yaml
+++ b/data/cards/playstation-visa.yaml
@@ -44,19 +44,18 @@ apr:
     min: 17.74
     max: 31.74
 our_take: >
-  The 5 points per dollar rate applies only at PlayStation, PlayStation
-  Direct, and the Sony Store, so this card's value tracks how much you spend
-  with Sony rather than how much you spend generally. Around that core, 3
-  points on streaming, cable, and internet subscriptions plus 2 points on
-  dining and groceries is respectable for a co-brand with no annual fee, with
-  everything else at 1 point per dollar. A $100 statement credit after $500 in
-  purchases within 60 days is an easy bonus to clear, and heavy users who put
-  $6,000 through the card in a calendar year get a 12 month PlayStation Plus
-  Premium membership. The constraints are the redemption path, points come
-  back as PlayStation Store codes and digital gift cards rather than cash, and
-  a foreign transaction fee that makes it a poor travel companion. Worth
-  carrying if the PlayStation ecosystem is where your money goes, hard to
-  justify if it is not.
+  The PlayStation Visa earns 5x points on PlayStation, PlayStation Direct and
+  Sony Store purchases, and since points redeem for PlayStation Store codes
+  and digital gift cards, that is the whole reason to hold it. Around that
+  core it is more useful than most co-brands, with 3x on streaming, cable and
+  internet subscriptions and 2x on dining and groceries, though everything
+  else earns 1x and there is no annual fee to worry about. The $100 statement
+  credit after $500 in purchases within 60 days is one of the easier bonuses
+  to clear. The perk worth planning around is a 12-month PlayStation Plus
+  Premium membership after $6,000 in purchases in a calendar year, which can
+  justify routing more spending here if you are already close. Just avoid it
+  overseas because of the foreign transaction fee, and pay in full: at 17.74%
+  to 31.74% the interest wipes out the points quickly.
 benefits:
   - name: "PlayStation Plus Premium Membership"
     value: 0

--- a/data/cards/pnc-cash-rewards.yaml
+++ b/data/cards/pnc-cash-rewards.yaml
@@ -57,14 +57,14 @@ benefits:
     frequency: "ongoing"
     category: "telecom"
 our_take: >
-  The tiered structure is the draw here: 4% back on gas, 3% on dining, and 2%
-  on groceries with no annual fee, a higher headline gas rate than most no-fee
-  cards offer. The catch is that all three share a single $8,000 annual cap
-  and drop to 1% after it, so figure roughly $667 a month across the pump,
-  restaurants, and the supermarket before the bonus rates stop. A $200 bonus
-  after $1,000 in purchases within 3 months and 15 months of 0% intro APR on
-  balance transfers make the first year the strongest one. Cell phone
-  protection is a genuine extra, up to $800 per claim with a $50 deductible
-  when you pay your wireless bill with the card, limited to 2 claims per 12
-  months. Leave it home when you travel, though, since it charges foreign
-  transaction fees and the regular APR runs 18.49% to 28.49%.
+  PNC Cash Rewards leads with an unusually high tier for a no annual fee card:
+  4% back on gas, 3% on dining and 2% on groceries. The real constraint is
+  that all three share a single $8,000 annual spending cap, after which they
+  all fall to 1%, so anyone who fills their tank and eats out regularly will
+  hit the ceiling well before the year is out. A $200 bonus after $1,000 in
+  the first three months is easy to clear, and 15 months of 0% intro APR on
+  balance transfers gives the card a second use for paying down debt, though
+  purchases are not covered. Cell phone protection worth up to $800 per claim
+  with a $50 deductible is a genuine extra if you pay your wireless bill with
+  the card. The foreign transaction fee keeps it domestic, and once the cap is
+  spent you will want something else for gas.

--- a/data/cards/pnc-cash-unlimited.yaml
+++ b/data/cards/pnc-cash-unlimited.yaml
@@ -39,14 +39,15 @@ benefits:
     frequency: "ongoing"
     category: "other"
 our_take: >
-  The pitch here is simplicity: a flat 2% cash back on everything with no
-  annual fee and no foreign transaction fees, so there are no categories to
-  track or activate. That flat rate holds up against most no-fee everyday
-  cards, and the lack of a foreign transaction fee makes it usable abroad
-  without a penalty. The 15 months of 0% intro APR applies to balance
-  transfers only, so don't count on it to float a new purchase. Cell phone
-  protection worth up to $800 per claim with a $50 deductible when you pay
-  your bill with the card is a real, if modest, add-on. There's no signup
-  bonus, so the value proposition is entirely about the long-run earn rate
-  rather than a first-year payout.
+  Cash Unlimited is the uncomplicated version of PNC's cash back lineup: a
+  flat 2% on everything, no categories to activate or track, no annual fee,
+  and no foreign transaction fee, which is more than plenty of flat-rate
+  rivals offer. The 15 months of 0% intro APR on balance transfers adds a
+  payoff window, although it does not extend to purchases. The extras are
+  modest but real, including cell phone protection up to $800 per claim with a
+  $50 deductible, purchase security on eligible items stolen or damaged within
+  90 days, and Visa Signature concierge. What it lacks is a signup bonus, so
+  there is no first-year sweetener to weigh against competitors that pay one.
+  Choose it if you want a single card that earns the same rate everywhere and
+  travels without a surcharge, not if you are shopping for upfront value.
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-cash-unlimited-visa-credit-card.html

--- a/data/cards/pnc-secured.yaml
+++ b/data/cards/pnc-secured.yaml
@@ -15,13 +15,13 @@ foreign_transaction_fee: true
 network: "visa"
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-secured-credit-card.html
 our_take: >
-  This is a credit-building tool rather than a rewards card: you put down a
-  deposit, PNC reports your activity, and you work toward qualifying for a
-  standard card later. The main thing in its favor is the $0 annual fee, which
-  keeps the cost of building or rebuilding credit close to zero if you pay in
-  full each month. Be clear about what you're not getting: no cash back, no
-  points, no signup bonus, and no intro APR, so there's no reason to carry a
-  balance at the 25.49% regular rate. The foreign transaction fee also makes
-  it a poor choice for travel purchases. Use it to establish a payment
-  history, then move on once you can qualify for something that actually
-  earns.
+  The PNC Secured card is a credit-building tool and little else: no rewards,
+  no signup bonus, no intro APR, just a card with no annual fee backed by a
+  security deposit. The missing annual fee is the main point in its favor,
+  because it means the cost of building history here comes down to interest
+  you choose to pay. That interest is expensive at a flat 25.49% APR, so the
+  only sensible way to use it is small charges paid in full each month. It
+  also carries a foreign transaction fee, which rules it out as a travel card
+  even for the occasional trip. Use it to establish a track record, then
+  graduate to a card that actually earns something once your credit supports
+  one.

--- a/data/cards/pnc-spend-wise.yaml
+++ b/data/cards/pnc-spend-wise.yaml
@@ -49,18 +49,18 @@ benefits:
     frequency: "ongoing"
     category: "telecom"
 our_take: >
-  The Spend Wise is built around one number: 18 months of 0% intro APR on both
-  purchases and balance transfers, with no annual fee. That's a long runway if
-  you're consolidating debt or spreading out a large purchase, and it covers
-  new spending as well as transferred balances rather than just one or the
-  other. PNC also layers on some unusual protections, including price
-  protection up to $1,000, coverage up to $10,000 per claim for packages
-  stolen within 90 days of purchase, and cell phone protection up to $800 per
-  claim with a $50 deductible. The catch is that the card earns no rewards at
-  all, so once the intro period ends there's little reason to keep spending on
-  it beyond the $25 in annual credits for eligible Spotify, Netflix, and
-  Disney+ charges. The APR reduction program, which shaves 2 percentage points
-  off your purchase APR for each 12-billing-cycle period in which you spend at
-  least $3,000 and pay on time, is a slow consolation for anyone who ends up
-  carrying a balance, and the foreign transaction fee rules it out for travel.
+  Spend Wise is a debt-payoff card first: 18 months of 0% intro APR on both
+  purchases and balance transfers, with no annual fee, which is one of the
+  longer dual runways on offer. It earns no rewards at all, so there is little
+  reason to keep spending on it once the intro window closes, but the ongoing
+  perks are unusually deep for a card in this lane. You get up to $25 a year
+  in credits toward Spotify, Netflix and Disney+ purchases, price protection
+  up to $1,000 if an eligible item drops in price within 60 days, coverage up
+  to $10,000 for packages stolen within 90 days of purchase, and cell phone
+  protection up to $800 per claim. There is also an APR reduction program that
+  trims your purchase rate by 2 percentage points for each 12-billing-cycle
+  review period in which you make at least $3,000 in net purchases and pay on
+  time, down to a set floor. Open it for the 18 months, build the payoff plan
+  around that deadline, and treat the credits as a bonus rather than the
+  reason.
 apply_link: https://www.pnc.com/en/personal-banking/banking/credit-cards/pnc-spend-wise-visa-credit-card.html

--- a/data/cards/princess-cruises-rewards-visa-card.yaml
+++ b/data/cards/princess-cruises-rewards-visa-card.yaml
@@ -6,16 +6,16 @@ slug: "princess-cruises-rewards-visa-card"
 accepting_applications: true
 apply_link: https://cards.barclaycardus.com/credit-card/b2e0e09c-e93c-43be-8758-57d22bb39ec1
 our_take: >
-  If you sail Princess with any regularity, the appeal is the 2 points per
-  dollar on Princess Cruises purchases, and the 20,000-point signup bonus
-  after $1,000 in spending within three months is easy to hit alongside a
-  deposit. There's no annual fee and no foreign transaction fee, which matters
-  on a card meant to travel with you. The 2x rate is limited to Princess
-  purchases specifically, and everything else earns just 1 point per dollar,
-  so this is not a card to put general spending on. The 15 months of 0% intro
-  APR applies to balance transfers only, not to new purchases, so it won't
-  help you finance the cruise itself. Worth carrying for the brand earn rate
-  and the bonus, but pair it with a stronger everyday card.
+  The Princess Rewards Visa, previously the Princess Cruises Rewards Visa, is
+  a narrow card by design: 2x points on Princess Cruises purchases and 1x on
+  everything else, which is not enough to justify daily use. Its strongest
+  feature is the 20,000-point bonus after $1,000 in the first three months, a
+  low bar for a bonus that size. There is no annual fee and no foreign
+  transaction fee, so it costs nothing to keep and works fine on a trip
+  abroad. It also carries 15 months of 0% intro APR on balance transfers, a
+  useful side benefit that has nothing to do with cruising. Realistically this
+  is a card you open for the bonus with a Princess sailing on the calendar,
+  then leave in a drawer.
 category: "travel"
 image: "barclays-princess.png"
 annual_fee: 0

--- a/data/cards/rakuten-american-express.yaml
+++ b/data/cards/rakuten-american-express.yaml
@@ -49,13 +49,14 @@ apr:
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  This is a shopper's card built around one ecosystem: 4% back on Rakuten.com
-  purchases on up to $10,000 of spending per calendar year, a cap raised from
-  $7,000 in July 2026, plus 5% on Rakuten Dining purchases. Outside that, 2%
-  on groceries and 2% on dining are reasonable but not category-leading, and
-  everything else drops to 1%. There's no annual fee and no foreign
-  transaction fee, so the card costs nothing to keep around for Rakuten runs.
-  Note that the signup bonus was cut in July 2026 from $200 to $100 after
-  $1,000 in spending within three months, which takes a lot of the first-year
-  shine off. The math only works if you genuinely shop through Rakuten; if you
-  don't, the 1% base rate makes this an easy pass.
+  The Rakuten American Express earns its keep only if you shop through
+  Rakuten: 4% back on Rakuten.com purchases on up to $10,000 of spending per
+  calendar year, a cap raised from $7,000 in July 2026, plus 5% on Rakuten
+  Dining. Off the platform it is ordinary, at 2% on groceries and dining and
+  1% on everything else, though the card has no annual fee and no foreign
+  transaction fee. The signup bonus was cut from $200 to $100 in July 2026, so
+  the upfront incentive is now half what it was for the same $1,000 of
+  spending over three months. The regular APR runs as high as 33.99%, which
+  makes this a poor place to carry a balance. Buy through Rakuten regularly
+  and the 4% and 5% tiers carry the card; if you do not, a general 2% cash
+  back card will do more for you.

--- a/data/cards/rei-co-op-mastercard.yaml
+++ b/data/cards/rei-co-op-mastercard.yaml
@@ -20,17 +20,16 @@ rewards:
     value: 1.5
     unit: percent
 our_take: >
-  For anyone who spends real money at REI, 5% back at REI retail locations and
-  REI.com is the reason to apply, and it sits on top of a card with no annual
-  fee and no foreign transaction fee. The 1.5% on everything else is
-  respectable enough that you're not penalized for using it away from REI,
-  though it won't beat a dedicated 2% card. The signup bonus is small and
-  oddly structured: a $100 REI gift card after your first purchase outside REI
-  within 60 days, with no real spending requirement, so it's easy money but
-  not a big first-year payout. Rewards come back as REI value rather than
-  flexible cash, so the card is only worth it if the co-op is already a
-  regular stop. The 17.49% to 28.49% regular APR and lack of any intro period
-  mean this is strictly a pay-in-full card.
+  If you shop at REI with any regularity, this is a straightforward way to add
+  5% back at REI retail locations and REI.com on top of whatever the co-op
+  already gives you, and it costs nothing to hold. Outside the co-op, the flat
+  1.5% back is fine but unremarkable, so this is a supplement to a stronger
+  everyday card rather than a replacement for one. The signup offer is modest
+  and oddly shaped: a $100 REI gift card after a single purchase made outside
+  REI within 60 days, so the reward comes back to you as store credit, not
+  cash. No foreign transaction fee is a real plus if you buy gear while
+  traveling. With a regular APR of 17.49% to 28.49% and no intro rate, treat
+  it as a spending card you pay off in full, not a financing tool.
 signup_bonus:
   value: 100
   type: cash

--- a/data/cards/robinhood-gold-card.yaml
+++ b/data/cards/robinhood-gold-card.yaml
@@ -43,14 +43,13 @@ apply_link: https://robinhood.com/creditcard/
 # 2026-07-01; accounts opened before that date are grandfathered with no fee.
 foreign_transaction_fee: true
 our_take: >
-  A flat 3% cash back on everything is the headline, and it is genuinely
-  higher than the usual 2% flat-rate standard, with 5% on travel booked
-  through the Robinhood travel portal for anyone willing to book there. The
-  $50 annual fee is low enough that the extra 1 percentage point over a 2%
-  card pays for itself once you put about $5,000 a year on it. Two real
-  caveats: there's a foreign transaction fee, which undercuts the 5% travel
-  angle for anything bought abroad, and the regular APR is a flat 29.99% with
-  no intro period, so carrying a balance wipes out the rewards fast. There's
-  no signup bonus, so the value is all in the ongoing rate rather than a
-  first-year payout. Travel insurance and cell phone protection when you pay
-  your bill with the card round it out.
+  The pitch here is unusually simple: a flat 3% back on everything, which is
+  higher than almost any no-category card asks you to think about, plus 5% on
+  travel booked through Robinhood's own portal. The $50 annual fee means you
+  need roughly $5,000 of yearly spending to come out ahead of a plain 2% card,
+  so this only works if it becomes your default for most purchases. Two
+  catches matter. There is a foreign transaction fee, which makes it a poor
+  travel companion despite the portal rate, and the APR is a flat 29.99% with
+  no intro period, so carrying a balance erases the rewards fast. Travel
+  insurance and cell phone protection when you pay your bill with the card are
+  useful but secondary reasons to hold it.

--- a/data/cards/robinhood-platinum.yaml
+++ b/data/cards/robinhood-platinum.yaml
@@ -109,20 +109,18 @@ apr:
 apply_link: https://robinhood.com/us/en/creditcard/platinum/
 foreign_transaction_fee: false
 our_take: >
-  The $695 annual fee only makes sense if you actually use the credits, and
-  there are a lot of them: $500 a year in hotel credits booked through the
-  Robinhood Banking app split $250 every six months, $300 in travel credits
-  split $150 every six months, $270 for health wearables, $250 for DoorDash,
-  $250 for autonomous rides, $250 in restaurant credits allotted monthly, and
-  up to $120 for Global Entry or TSA PreCheck every four years. On paper that
-  far exceeds the fee, but most of it is narrow, semi-annual, or tied to
-  specific merchants, so treat the fee as real money unless your spending
-  already lines up. The earn structure is similarly portal-dependent: 10% on
-  hotels and car rentals and 5% on flights only when booked through the
-  Robinhood Banking app, 5% on dining anywhere, and just 1% on everything
-  else, which is a weak base rate for a premium card. Unlimited Priority Pass
-  lounge access, a complimentary Robinhood Gold membership, One Medical,
-  Function Health, and DashPass fill out the perk list. There's no signup
-  bonus and the APR is a flat 29.99%, so this is a card for people who will
-  work the credits methodically and never carry a balance.
+  This is a $695 card built around statement credits rather than earn rates,
+  and the credits are substantial on paper: $500 a year for hotels booked in
+  the Robinhood Banking app, $300 in travel credits, $270 for health
+  wearables, $250 for DoorDash, $250 for restaurants, $250 for eligible
+  autonomous rides, and up to $120 for Global Entry or TSA PreCheck every four
+  years. Unlimited Priority Pass lounge access, complimentary Robinhood Gold,
+  One Medical, and Function Health memberships round it out. The earn
+  structure is the weak half: 10% on hotels and car rentals and 5% on flights
+  only when booked through the Robinhood Banking app, 5% on dining, and just
+  1% on everything else, so this is not a card to put general spending on.
+  Whether it clears the fee depends entirely on how many of those specific
+  credits you would actually use, and several of them are narrow. The 29.99%
+  APR is steep, so this is a card for people who pay in full and book travel
+  where Robinhood wants them to.
 

--- a/data/cards/sams-club-mastercard.yaml
+++ b/data/cards/sams-club-mastercard.yaml
@@ -50,15 +50,14 @@ benefits:
     frequency: "ongoing"
     category: "shopping"
 our_take: >
-  The standout rate is 5% back on gas and EV charging worldwide, including
-  Sam's Club stations, on the first $6,000 each year before it drops to 1%,
-  which is one of the better gas rates available without an annual fee. Dining
-  and takeout earn 3%, and the card doubles as your membership credential at
-  the door and register, which is a small but genuine convenience. Read the
-  fine print on the wholesale club rate: 3% back on Sam's Club purchases
-  applies only to Plus members, while Club-tier members earn 1%, so a big
-  chunk of the pitch depends on paying for the higher membership tier. Total
-  card earnings are capped at $5,000 in Sam's Cash per calendar year,
-  everything else earns 1%, and the signup bonus is a token $30 statement
-  credit after $30 in Sam's Club purchases within 30 days. It's a solid
-  fuel-and-warehouse companion card rather than an everyday spender.
+  The headline is 5% back on gas and EV charging worldwide, including Sam's
+  Club stations, on the first $6,000 each year, which is one of the better
+  fuel rates available for no annual fee. Add 3% on dining and takeout and,
+  for Plus members, 3% on Sam's Club purchases, and it covers a decent slice
+  of a household budget. Two ceilings limit the upside: gas drops to 1% past
+  $6,000, and total card earnings are capped at $5,000 in Sam's Cash per
+  calendar year. Club-tier members earn only 1% at Sam's Club, so the
+  wholesale-club rate is really a Plus-member benefit, and everything outside
+  those categories earns a flat 1%. The signup offer is small at $30 after $30
+  in Sam's Club purchases in the first 30 days, and the card doubling as your
+  membership card at the door is a convenience rather than a reason to apply.

--- a/data/cards/samsung-galaxy-card.yaml
+++ b/data/cards/samsung-galaxy-card.yaml
@@ -54,15 +54,15 @@ benefits:
     merchants:
       - samsung
 our_take: >
-  If you buy from Samsung directly, this card is aimed squarely at you: 5%
-  back on purchases made in-store or online from Samsung in the U.S., plus a
-  $200 bonus after $2,000 in spending in the first 90 days, with no annual fee
-  and no foreign transaction fee. The 3% rate is narrower than it looks, since
-  it applies only when you pay through Samsung Wallet; anything bought with
-  the physical card or outside the wallet earns the 1% base rate. Streaming
-  services sit at 2%, so outside Samsung purchases and wallet-paid spending
-  there isn't much reason to reach for it. The 20% discount on the $149.99
-  Samsung VIP Advantage membership when you pay with the card is a fair perk
-  for people already in that ecosystem. With a regular APR of 23.49% to 32.24%
-  and no intro period, treat this as a pay-in-full card tied to Samsung
-  purchases rather than a general-purpose earner.
+  This card makes the most sense if you buy from Samsung directly and pay with
+  Samsung Wallet, because those are the only places its rates get interesting:
+  5% back on purchases made directly from Samsung in the U.S., and 3% back on
+  any purchase paid through Samsung Wallet. Outside those conditions the card
+  earns 1%, so the physical card in your pocket is a weak everyday earner,
+  with 2% on streaming services the only other bright spot. There is no annual
+  fee and no foreign transaction fee, and the $200 bonus after $2,000 in the
+  first 90 days is reasonable for a card at this level. Launched in July 2026,
+  it also knocks 20% off the $149.99 Samsung VIP Advantage membership when you
+  pay with it. The regular APR of 23.49% to 32.24% is high with no intro
+  offer, so this is for Samsung loyalists paying in full, not for carrying a
+  balance.

--- a/data/cards/southwest-rapid-rewards-performance-business-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-performance-business-credit-card.yaml
@@ -99,18 +99,17 @@ benefits:
     frequency: "ongoing"
     category: "business"
 our_take: >
-  This is the Southwest card for a business that actually flies Southwest
-  often enough to use the perks: 4x points on Southwest Airlines purchases,
-  9,000 bonus points every anniversary, free first checked bag for you and up
-  to eight people on the reservation, Group 5 boarding, and unlimited Extra
-  Legroom upgrades within 48 hours of departure when available. The current
-  offer is 80,000 points after $5,000 in spend within three months, and
-  employee cards come at no extra cost. Away from the airport the earn is
-  ordinary: 2x on gas, dining, transit, and hotels booked directly with the
-  hotel, then 1x on everything else, so this is not a card to put general
-  business spend on. The $299 annual fee is the real hurdle, and the 4x rate
-  is gated to Southwest purchases only, so the math depends on you clearing
-  that fee with bag waivers, the anniversary points, and the up to $120 Global
-  Entry or TSA PreCheck credit every four years. The 2,500 tier qualifying
-  points per $5,000 spent and 10,000 Companion Pass qualifying points a year
-  matter mainly if you are chasing A-List or a Companion Pass.
+  The Performance Business is the top of Chase's Southwest business lineup,
+  and it earns like it: 4 points per dollar on Southwest purchases, plus 2
+  points on gas, dining, hotels booked directly, and transit including
+  rideshare. The $299 annual fee is the real hurdle, but 9,000 anniversary
+  points, free unlimited Extra Legroom upgrades within 48 hours of departure,
+  complimentary seat selection at booking, a free first checked bag for you
+  and up to eight passengers, Group 5 boarding, and up to $120 back on Global
+  Entry or TSA PreCheck do a lot of work against it. For anyone chasing
+  status, the 2,500 tier qualifying points per $5,000 spent is the fastest
+  A-List path in this family, and 10,000 Companion Pass qualifying points a
+  year helps toward the pass without counting toward flights. The signup bonus
+  is 80,000 points after $5,000 in three months. If your business does not fly
+  Southwest often, the fee is hard to justify and a cheaper card in the lineup
+  will serve you better.

--- a/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-plus-credit-card.yaml
@@ -105,17 +105,18 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/plus
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Plus is the entry point to Southwest's lineup, and its appeal is the low
-  bar: 50,000 points after just $1,000 in spend within three months, which is
-  one of the easier bonuses to clear for a $99 annual fee. Ongoing perks are
-  decent for the price, including 3,000 anniversary points, a free first
-  checked bag for you and up to eight passengers, 10,000 Companion Pass
-  qualifying points a year, a 10% flight discount code each anniversary year,
-  and no foreign transaction fees. Be honest about the earn rate, though: the
-  2x on Southwest applies only to Southwest Airlines purchases, gas and
-  groceries earn 2x on just the first $5,000 a year before dropping to 1x, and
-  everything else is 1x. Note the bonus timing too: it jumped to 80,000 points
-  in late May and fell back to 50,000 in early July, so this is the low end of
-  its recent range. It ranks fourth on our Best Airline Credit Cards list, and
-  it fits an occasional Southwest flyer who wants the checked bag and
-  Companion Pass points without paying $149 or more.
+  The Plus is the entry point to Southwest's consumer lineup, and it is priced
+  that way at a $99 annual fee with 3,000 anniversary points that recover a
+  chunk of it. Earning is modest: 2 points per dollar on Southwest, plus 2
+  points at gas stations and grocery stores on the first $5,000 each year
+  before dropping to 1, and 1 point on everything else. The reason to hold it
+  is the perks, not the rates: a free first checked bag for you and up to
+  eight passengers on the same reservation, a 10% flight discount code each
+  anniversary year, 25% back on inflight drinks and Wi-Fi, no foreign
+  transaction fees, and 10,000 Companion Pass qualifying points deposited each
+  year. On the signup bonus, be aware the offer briefly rose to 80,000 points
+  in late May before returning to 50,000 after $1,000 in three months on July
+  3, so it is worth watching for the next spike. It ranks #12 on our Best
+  Airline Credit Cards list, which is about right: fine for occasional
+  Southwest flyers, but the Premier and Priority earn more per dollar if you
+  fly enough to care.

--- a/data/cards/southwest-rapid-rewards-premier-business-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-business-credit-card.yaml
@@ -95,16 +95,18 @@ benefits:
     category: "travel"
     enrollment_required: false
 our_take: >
-  The Premier Business sits in the middle of Chase's Southwest business lineup
-  and earns its keep on the flying perks rather than the earn rate: 6,000
-  anniversary points, a free first checked bag for you and up to eight
-  passengers, Group 5 boarding, a 15% flight promo code each anniversary year,
-  and 10,000 Companion Pass qualifying points annually. The bonus is 60,000
-  points after $3,000 in spend within three months, and employee cards are
-  free and can carry individual spending limits. On rewards it is thin: 3x is
-  limited to Southwest Airlines purchases, gas and restaurants share a
-  combined $8,000 annual cap at 2x before falling to 1x, and the rest is 1x,
-  so this should not be your everyday business card. At $149 a year the fee is
-  defensible if you check bags on even a few Southwest trips, but it is dead
-  weight if your team flies other airlines. The 2,000 tier qualifying points
-  per $5,000 spent nudges you toward A-List without doing much on its own.
+  The Premier Business sits in the middle of Chase's Southwest business
+  lineup: a $149 annual fee against 6,000 anniversary points, which cuts the
+  real cost meaningfully if you fly Southwest at all. It earns 3 points per
+  dollar on Southwest purchases and 2 points at gas stations and restaurants
+  up to a combined $8,000 a year, then 1 point on everything after that, so it
+  is not a card to run all your business spending through. The travel perks
+  are where it earns its keep: a free first checked bag for you and up to
+  eight passengers, Group 5 boarding, complimentary Standard or Preferred seat
+  selection within 48 hours of departure, 25% back on inflight drinks and
+  Wi-Fi, and a 15% promo code each anniversary year. It also adds 10,000
+  Companion Pass qualifying points a year and 2,000 tier qualifying points per
+  $5,000 spent toward A-List, plus employee cards at no cost with individual
+  spending limits. The signup bonus is 60,000 points after $3,000 in three
+  months. If you want faster status accrual and richer seat perks, the
+  Performance Business does more for $150 more.

--- a/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-premier-credit-card.yaml
@@ -105,18 +105,18 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/premier
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Premier is the middle Southwest card and makes the most sense for
-  someone who flies Southwest a few times a year and checks a bag: 6,000
-  anniversary points, a free first checked bag for you and up to eight
-  passengers, 10,000 Companion Pass qualifying points a year, and a 15% flight
-  promo code each anniversary year, all for a $149 annual fee. The current
-  bonus is 55,000 points after $1,500 in spend within three months, which is a
-  low spend hurdle, though worth noting it briefly hit 85,000 in late May
-  before returning to 55,000 in early July. The earn structure is where it
-  thins out: 3x applies only to Southwest Airlines purchases, groceries and
-  dining earn 2x on just the first $8,000 a year before dropping to 1x, and
-  everything else is 1x. Up to $120 in annual Instacart credits and a one-year
-  DashPass membership both require enrollment and only pay off if you already
-  use those services. It sits sixth on our Best Airline Credit Cards list, and
-  the honest test is whether the anniversary points and bag waivers cover the
-  fee on your actual flying.
+  The Premier is the middle option in Southwest's consumer lineup, and the
+  math is simple: a $149 annual fee against 6,000 anniversary points every
+  year, which softens the cost considerably. It earns 3 points per dollar on
+  Southwest purchases and 2 points at grocery stores and restaurants on the
+  first $8,000 a year before dropping to 1, so treat it as a Southwest card
+  rather than a general spender. The perks are solid for the price: a free
+  first checked bag for you and up to eight passengers, complimentary
+  Preferred seat selection within 48 hours of departure, a 15% anniversary
+  promo code, 25% back on inflight purchases, up to $120 in annual Instacart
+  credits, and 10,000 Companion Pass qualifying points a year. One timing note
+  on the bonus: it jumped to 85,000 points in late May and fell back to 55,000
+  after $1,500 in three months on July 3, so waiting for the next elevated
+  offer is worth considering. Ranked #9 on our Best Airline Credit Cards list,
+  it is the sensible middle choice unless you fly enough to use the Priority's
+  Extra Legroom upgrades and $75 travel credit.

--- a/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
+++ b/data/cards/southwest-rapid-rewards-priority-credit-card.yaml
@@ -102,16 +102,19 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/southwest/priority
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Priority is the top consumer Southwest card, and it is the one where the
-  recurring credits do the heavy lifting: a $75 annual Southwest travel credit
-  and 7,500 anniversary points offset most of the $229 annual fee before you
-  fly anywhere. On top of that you get a free first checked bag for you and up
-  to eight passengers, complimentary Preferred seat selection at booking,
-  unlimited Extra Legroom upgrades within 48 hours of departure when
-  available, and 10,000 Companion Pass qualifying points each year. The bonus
-  is currently 60,000 points after $2,000 in spend within three months, down
-  from the 90,000 that ran from late May to early July, so patience may pay if
-  you are not in a hurry. Rewards outside the airline are modest: 4x is gated
-  to Southwest Airlines purchases, gas and dining earn 2x, and everything else
-  is 1x. It ranks fifth on our Best Airline Credit Cards list and works best
-  for a regular Southwest flyer, not as a general spending card.
+  The Priority is the strongest consumer card in Southwest's lineup and the
+  easiest one to justify on paper: the $229 annual fee is offset by a $75
+  annual Southwest travel credit and 7,500 anniversary points, which leaves a
+  fairly small net cost if you fly the airline at all. It earns 4 points per
+  dollar on Southwest purchases including flights, inflight, and gift cards,
+  plus 2 points on gas and dining and 1 point elsewhere. The seat perks are
+  the real separator: unlimited Extra Legroom upgrades within 48 hours of
+  departure when available, complimentary Preferred seat selection at booking,
+  a free first checked bag for you and up to eight passengers, and 25% back on
+  inflight purchases. It also earns 2,500 tier qualifying points per $5,000
+  spent toward A-List and 10,000 Companion Pass qualifying points each year,
+  though those Companion Pass points do not count toward flight redemptions.
+  On the bonus, note it rose to 90,000 points in late May and returned to
+  60,000 after $2,000 in three months on July 3, so a better offer may come
+  around again. It ranks #7 on our Best Airline Credit Cards list, and the
+  case for it collapses entirely if Southwest is not your main airline.

--- a/data/cards/target-circle-card.yaml
+++ b/data/cards/target-circle-card.yaml
@@ -49,9 +49,8 @@ our_take: >
   and Target subscriptions, with no annual fee. Frequent shoppers also get
   free two-day shipping on eligible Target.com items, an extra 30 days to
   return purchases, and 50% off the $99 Target Circle 360 membership. The
-  signup bonus briefly doubled to $100 in early August and was cut back to $50
-  after $500 in spend within two months on August 31, so it is a modest
-  sweetener rather than a reason to apply. The real limitation is scope:
+  current signup bonus is $50 in Target Circle Rewards upon approval, so it is
+  a modest sweetener rather than a reason to apply. The real limitation is scope:
   outside of Target the store version earns nothing, and prescriptions, gift
   cards, and some services are excluded even inside the store. With a 27.4%
   regular APR, this only works as a card you pay in full, and it belongs

--- a/data/cards/target-circle-card.yaml
+++ b/data/cards/target-circle-card.yaml
@@ -44,16 +44,15 @@ benefits:
     category: "shopping"
     enrollment_required: true
 our_take: >
-  If you shop at Target with any regularity, this is one of the simplest wins
-  available: a straight 5% discount taken off at checkout in stores and on
-  Target.com, including in-store Starbucks and Target subscriptions, with no
-  annual fee. The welcome offer recently doubled from $50 to $100, split
-  between $50 in Target Circle Rewards on approval and another $50 after $500
-  in spend within 60 days, though the approval half ends September 26, 2026
-  and the spend half ends August 29, 2026. Free two-day shipping on eligible
-  Target.com items, an extra 30 days on returns, and 50% off the $99 Target
-  Circle 360 membership round out a sensible store-card package. The limits
-  are real, though: the 5% applies only at Target and excludes Target
-  GiftCards, prescriptions, and some services, and unless you are approved for
-  the Mastercard version there is nothing to earn outside the store. The 27.4%
-  APR is high, so treat this strictly as a pay-in-full discount card.
+  If you shop at Target regularly, the math here is hard to argue with: an
+  instant 5% off at Target stores and Target.com, including in-store Starbucks
+  and Target subscriptions, with no annual fee. Frequent shoppers also get
+  free two-day shipping on eligible Target.com items, an extra 30 days to
+  return purchases, and 50% off the $99 Target Circle 360 membership. The
+  signup bonus briefly doubled to $100 in early August and was cut back to $50
+  after $500 in spend within two months on August 31, so it is a modest
+  sweetener rather than a reason to apply. The real limitation is scope:
+  outside of Target the store version earns nothing, and prescriptions, gift
+  cards, and some services are excluded even inside the store. With a 27.4%
+  regular APR, this only works as a card you pay in full, and it belongs
+  alongside a general everyday card rather than replacing one.

--- a/data/cards/td-double-up.yaml
+++ b/data/cards/td-double-up.yaml
@@ -34,14 +34,14 @@ apply_link: https://www.td.com/us/en/personal-banking/credit-cards/double-up
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Double Up is a flat-rate cash back card with a clean pitch: 2% back on
-  everything with no annual fee and no categories to track or activate. It
-  pairs that with a $200 bonus after $1,500 in spend within three months and a
-  genuinely useful intro APR, 0% for 12 months on purchases and 15 months on
-  balance transfers, which gives it double duty as a payoff card. Two catches
-  deserve attention. First, rewards accrue as points and you need 2,500 of
-  them, meaning $25 in value, before you can redeem for a statement credit or
-  a deposit into a TD checking or savings account. Second, it charges foreign
-  transaction fees, so leave it home when you travel abroad. As a domestic
-  everyday card for someone who wants one rate on all spending, it does the
-  job without asking for anything back.
+  The TD Double Up is a flat-rate cash back card: 2% on everything, with no
+  annual fee and no categories to track or activate. There is a $200 bonus
+  after $1,500 in spend within three months, plus a long financing window of
+  0% intro APR for 12 months on purchases and 15 months on balance transfers
+  before the rate moves to 18.49% to 28.49%. Two details temper it. Rewards
+  accrue as points and you need at least 2,500 points, meaning $25, before you
+  can cash out to a statement credit or a TD checking or savings account, and
+  the card charges foreign transaction fees, so leave it home when you travel
+  abroad. As a domestic 2% workhorse with a useful transfer runway attached,
+  it does the job; just do not expect it to earn anything above that flat
+  rate.

--- a/data/cards/the-business-platinum-card-from-american-express.yaml
+++ b/data/cards/the-business-platinum-card-from-american-express.yaml
@@ -166,20 +166,20 @@ apply_link: https://www.americanexpress.com/us/credit-cards/business/business-cr
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  The Business Platinum's case is credits and lounges, not earn rate, and the
-  current welcome offer sharpens it: 300,000 points after $20,000 in spend
-  within three months, up from 200,000 in mid-July. The annual credits are
-  large but scattered across specific vendors: $360 a year at Indeed in $90
-  quarterly chunks, $250 at Adobe after $600 in annual spend, $219 for CLEAR
-  Plus, $200 in airline incidental fees on one selected airline, $200 at
-  Hilton properties in $50 quarterly pieces, $150 back at Dell, $120 in
-  monthly wireless credits, and $300 in ChatGPT credits, nearly all of which
-  require enrollment and only count if you were already spending there. Lounge
-  access is the least conditional benefit: Centurion Lounges, Priority Pass
-  Select, and 10 Delta Sky Club visits a year on eligible Delta flights. The
-  earn structure is lopsided, with 5x confined to flights and prepaid hotels
-  booked through Amex Travel and a 1x base rate elsewhere, lifted to 2x only
-  on specific U.S. business categories or single purchases of $5,000 or more.
-  At $895 a year, this card works only if you genuinely use several of those
-  credits and fly enough to value the lounges, otherwise the fee outruns the
-  benefits.
+  The current 300,000 point signup bonus after $20,000 in spend within three
+  months, raised from 200,000 in July, is the strongest reason to look at the
+  Business Platinum right now. Ongoing, the card earns 5x on flights and
+  prepaid hotels booked through Amex Travel, plus 2x at U.S. construction and
+  hardware suppliers, U.S. electronics retailers, software and cloud
+  providers, U.S. shipping providers, and on any eligible purchase of $5,000
+  or more up to $2M a year. The $895 annual fee is the obvious hurdle, and it
+  is only recoverable if you actually use the credit stack: $360 a year for
+  Indeed job postings, $200 in Hilton for Business credits, $250 for Adobe,
+  $200 in airline incidental fees, $150 at Dell, $120 in monthly wireless
+  credits, $300 for ChatGPT, and up to $600 a year at Fine Hotels + Resorts or
+  The Hotel Collection. Nearly all of those require enrollment and are tied to
+  specific vendors, so a business that does not spend at Indeed, Adobe, Dell,
+  Hilton, or on U.S. wireless service will not come close to breaking even.
+  Note too that the base rate outside those bonus lanes is just 1x, which
+  makes this a lounge access and credit stacking card rather than an everyday
+  spend card.

--- a/data/cards/the-platinum-card.yaml
+++ b/data/cards/the-platinum-card.yaml
@@ -8,21 +8,21 @@ foreign_transaction_fee: false
 network: "amex"
 card_referral_link: "https://americanexpress.com/en-us/referral/platinum-card?ref="
 our_take: >
-  The Platinum Card currently ranks #1 on our Best Credit Card Signup Bonuses
-  list, and the reason is straightforward: 175,000 points after $12,000 in
-  purchases in six months. Ongoing earning is narrow, though: 5x points on
-  airfare booked directly with airlines or through Amex Travel (up to $500,000
-  per year, then 1x) and 5x on prepaid hotels through AmexTravel.com, with a
-  flat 1x on everything else. What has to justify the $895 annual fee is the
-  credit stack, including up to $600 in Fine Hotels + Resorts or Hotel
-  Collection credits, $400 at Resy restaurants, $300 in digital entertainment,
-  $300 at Equinox, $300 at Lululemon, $200 in Uber Cash, and $219 for CLEAR
-  Plus, plus Centurion Lounge and Priority Pass access. The catch is that
-  those credits arrive in monthly, quarterly, and semi-annual slices and most
-  require enrollment, so you only come out ahead if your spending already runs
-  through Uber, Resy, Lululemon, and Amex Travel hotel bookings. If you would
-  not naturally use most of them, that 1x base rate makes this a costly card
-  to keep.
+  The Platinum earns 5x on airfare booked directly with airlines or through
+  Amex Travel, up to $500,000 a year, and 5x on prepaid hotels through
+  AmexTravel.com, paired with a 175,000 point bonus after $12,000 in spend
+  over six months that currently ranks second on our Best Credit Card Signup
+  Bonuses list. Lounge access is the ongoing draw: Centurion Lounges, Priority
+  Pass Select, and 10 Delta Sky Club visits a year when flying Delta. The $895
+  annual fee is only justified if you methodically use the credits, which
+  include up to $600 a year in Fine Hotels + Resorts or Hotel Collection
+  bookings, $400 at Resy restaurants, $300 in monthly digital entertainment
+  credits, $300 for Equinox, $300 for Lululemon, $200 in Uber Cash, $200 in
+  airline incidental fees, and $219 for CLEAR Plus. Most of those require
+  enrollment and arrive in monthly or quarterly slices, so unused months are
+  gone for good, and a card that pays only 1x outside airfare and portal
+  hotels is not the one to put everyday spending on. Treat it as a travel and
+  credits subscription you either work at or should not buy.
 annual_fee: 895
 reward_type: "points"
 rewards:

--- a/data/cards/truist-business-cash-rewards.yaml
+++ b/data/cards/truist-business-cash-rewards.yaml
@@ -61,14 +61,17 @@ benefits:
     category: "business"
 apply_link: https://www.truist.com/small-business/credit-cards/business-cash-rewards
 our_take: >
-  Truist Business Cash Rewards pairs a $300 bonus after $3,000 in purchases in
-  three months with 3% back on gas and 2% on dining and office supplies, all
-  for no annual fee. Nine months of 0% intro APR on purchases adds some
-  breathing room on early expenses. Read the cap carefully: the 3% and 2%
-  categories share a combined $2,000 per month, and anything past that earns
-  1%, the same as everything else. The Loyalty Cash Bonus can add 10%, 25%, or
-  50% to your rewards, but only when you redeem into a Truist business deposit
-  account, and the tier is set by your banking relationship, so plan on the
-  10% floor. It is a fair no-fee pick for a Truist customer with modest,
-  gas-heavy spend, and a weak one if your category spending regularly clears
-  $2,000 a month.
+  For a no annual fee business card, the earn structure here is reasonable: 3%
+  back on gas and 2% on dining and office supplies, plus a $300 bonus after
+  $3,000 in spend within three months and 0% intro APR on purchases for the
+  first nine months. Truist customers get an extra angle through the Loyalty
+  Cash Bonus, which adds 10%, 25%, or 50% on top of rewards redeemed into an
+  eligible Truist business deposit account depending on your relationship
+  tier. The catch is the cap: the 3% and 2% categories share a combined $2,000
+  monthly limit, and everything past that drops to 1%, so the bonus rates are
+  worth at most a few hundred dollars a year for most businesses. Everything
+  outside those categories earns a flat 1%, which is below what a plain 2%
+  business card would pay. Employee cards are free, and the go-to APR of
+  15.74% to 24.74% is on the lower end, but this card really only makes sense
+  if you bank with Truist and your gas, dining, and office supply spend fits
+  inside the cap.

--- a/data/cards/truist-business-premium.yaml
+++ b/data/cards/truist-business-premium.yaml
@@ -46,13 +46,15 @@ benefits:
     category: "business"
 apply_link: https://www.truist.com/small-business/credit-cards/business-premium-rewards
 our_take: >
-  Truist Business Premium is built for volume: a flat 2% back on every
-  purchase with no categories to track, plus a $1,000 bonus after $15,000 in
-  spend in the first three months. The $299 annual fee is waived for the first
-  12 months, and waived again in any year the business puts $100,000 or more
-  on the card. That $100,000 line is the entire calculation. Clear it and you
-  are earning $2,000 or more at 2% with no fee; fall short and the fee bites,
-  since $50,000 of spend earns $1,000 and the $299 charge drops the effective
-  rate to roughly 1.4%. Redeeming into a Truist business deposit account adds
-  a 10% bonus, and employee cards cost nothing, but neither changes the
-  spending threshold this card is designed around.
+  A flat 2% back on every purchase with no categories to manage is the whole
+  pitch, and the $1,000 bonus after $15,000 in spend within three months is a
+  solid opener for a business with real volume. The $299 annual fee is waived
+  for the first 12 months and waived again in any year the card sees $100,000
+  or more in eligible purchases, which is the number to focus on: below that
+  threshold you are paying $299 for a rate that plenty of business cards offer
+  for free. At $100,000 in annual spend the 2% return is $2,000 and the fee
+  disappears, so the card is genuinely strong at the top of its range and hard
+  to justify at the bottom. Truist depositors get a 10% bonus on rewards
+  redeemed into an eligible business deposit account, a small but real bump.
+  There are no travel perks or category multipliers here, so judge it purely
+  on whether your spend clears the waiver.

--- a/data/cards/truist-business-travel-rewards.yaml
+++ b/data/cards/truist-business-travel-rewards.yaml
@@ -57,15 +57,16 @@ benefits:
     category: "business"
 apply_link: https://www.truist.com/small-business/credit-cards/business-travel-rewards
 our_take: >
-  For a $49 annual fee that is waived the first year, Truist Business Travel
-  Rewards nearly covers its own cost with a $120 Global Entry or TSA PreCheck
-  credit once every four years, and it charges no foreign transaction fees on
-  overseas spending. The earn structure is simple: 2x miles on airfare,
-  hotels, and car rentals, 1x on everything else, plus 20,000 miles after
-  $2,000 in purchases in three months. The Loyalty Travel Bonus can lift
-  travel redemptions by 10%, 25%, or 50%, but the tier depends on your Truist
-  deposit relationship, so most applicants should budget on the 10% version.
-  The real weakness is that 1x base rate, which means the card only pays off
-  on its three travel categories. It fits a small business that travels
-  regularly and already banks with Truist, and not one whose spending is
-  mostly vendors and office bills.
+  This is an entry-level business travel card: 2x miles on airlines, hotels,
+  and car rentals, 1x elsewhere, no foreign transaction fees, and a $49 annual
+  fee that is waived the first year. The 20,000 mile bonus after just $2,000
+  in spend within three months is an unusually low hurdle, and the card covers
+  a Global Entry or TSA PreCheck application fee up to $120 once every four
+  years, which alone more than offsets two years of the fee. Truist depositors
+  can add 10%, 25%, or 50% to the value of miles redeemed for travel depending
+  on their relationship tier, which is where this card gets most interesting.
+  The tradeoff is a thin ceiling: 2x on travel and 1x on everything else is
+  modest by business card standards, and there is no lounge access or travel
+  credit to fall back on. It suits a small business that already banks with
+  Truist and wants cheap, no-fuss travel earning, not one chasing premium
+  perks.

--- a/data/cards/truist-business.yaml
+++ b/data/cards/truist-business.yaml
@@ -24,12 +24,13 @@ benefits:
     category: "business"
 apply_link: https://www.truist.com/small-business/credit-cards/business-card
 our_take: >
-  The Truist Business card is a financing tool rather than a rewards card: 12
-  months of 0% intro APR on purchases with no annual fee, which is a workable
-  way to spread out equipment or inventory costs. The go-to rate afterward,
-  13.74% to 22.74%, is lower than many business cards start at, so a lingering
-  balance is less punishing than usual. The tradeoff is absolute: this card
-  earns nothing on any purchase, no cash back and no points. Free employee
-  cards are the only ongoing perk on offer. Open it for the interest-free
-  year, then put your everyday business spending on something that actually
-  earns.
+  The Truist Business card is a financing tool, not a rewards card: 0% intro
+  APR on purchases for 12 months with no annual fee, then a go-to rate of
+  13.74% to 22.74% that is low by business card standards. That combination
+  makes it a reasonable place to put a large equipment or inventory purchase
+  you intend to pay off over the first year, and free employee cards let you
+  extend it across a team without extra cost. Be clear about what you are
+  giving up: the card earns no cash back, points, or miles at all, and there
+  is no signup bonus. Once the intro window closes there is nothing left to
+  make it your daily business card. Open it for the 0% runway, plan the
+  payoff, and keep an earning card for everyday spend.

--- a/data/cards/truist-enjoy-beyond.yaml
+++ b/data/cards/truist-enjoy-beyond.yaml
@@ -57,15 +57,16 @@ benefits:
     category: "rewards"
 apply_link: https://www.truist.com/credit-cards/enjoy-beyond
 our_take: >
-  Truist Enjoy Beyond earns 3x points on airfare, hotels, and car rentals plus
-  2x on dining, a respectable set of travel multipliers for a $95 annual fee.
-  The $100 annual credit for ground transportation, streaming, and ticket
-  agencies, together with the $120 Global Entry or TSA PreCheck credit every
-  four years, offsets most of that fee if you actually use them, and there are
-  no foreign transaction fees. The signup bonus is easy to clear at 30,000
-  points after just $1,500 in three months. The limits are the flat 1x on
-  everything outside those categories and the Loyalty Cash Bonus, whose 25%
-  and 50% tiers are set by how much you keep in Truist deposit accounts, so
-  assume the 10% floor unless you bank heavily there. Worth carrying if you
-  travel a few times a year and are already a Truist customer; otherwise $95
-  is hard to earn back on 1x spending.
+  Enjoy Beyond pays 3x points on airlines, hotels, and car rentals and 2x on
+  dining, with a $95 annual fee and no foreign transaction fees, which is a
+  competitive rate set for the price. The 30,000 point bonus after only $1,500
+  in spend within three months is an easy target, and the card adds up to $100
+  a year in statement credits for ground transportation, streaming, and ticket
+  agencies plus a Global Entry or TSA PreCheck credit worth up to $120 every
+  four years. Between the annual credit and the application fee reimbursement,
+  the fee is straightforward to cover. The real variable is the Loyalty Cash
+  Bonus, which adds 10% to 50% on points redeemed into an eligible Truist
+  deposit account based on your combined balances, so the card's value swings
+  widely depending on how much you keep with Truist. Everything outside travel
+  and dining earns 1x, and there is no lounge access, so this is a mid-tier
+  travel card for Truist customers rather than a premium one.

--- a/data/cards/truist-enjoy-cash-1-5.yaml
+++ b/data/cards/truist-enjoy-cash-1-5.yaml
@@ -35,14 +35,15 @@ benefits:
 apply_link: https://creditcard.digitalcommerce.truist.com/product/CRW
 page_check_url: https://www.truist.com/credit-cards/enjoy-cash
 our_take: >
-  Truist Enjoy Cash 1.5% is a simple no-fee flat-rate card: 1.5% back on
-  everything, no categories to track, no caps, and no foreign transaction
-  fees. The 12 months of 0% intro APR on both purchases and balance transfers
-  give it a second use as a short-term payoff card. Be clear about the
-  ceiling, though: 1.5% sits below what tiered cards pay in their bonus
-  categories, and there is no signup bonus at all to sweeten the first year.
-  The Loyalty Cash Bonus can add 10% to 50% on top, but only when you redeem
-  into a Truist deposit account, and only at the tier your combined balances
-  qualify for, which for most people means the 10% end. It makes the most
-  sense as a catch-all for someone who already banks with Truist rather than
-  as the centerpiece of a wallet.
+  This is about as simple as a card gets: a flat 1.5% cash back on everything,
+  no annual fee, no foreign transaction fees, and 0% intro APR for 12 months
+  on both purchases and balance transfers. The intro window is the strongest
+  part of the offer, giving you a year to pay down a transferred balance or
+  spread out a large purchase before the rate moves to 18.74% to 27.74%. Where
+  it gets more interesting is the Loyalty Cash Bonus: redeeming into an
+  eligible Truist deposit account adds 10% to 50% to your rewards depending on
+  your combined balances, which can push the effective rate above 1.5%.
+  Without that relationship, though, 1.5% flat is below what several no annual
+  fee cards pay, and this one carries no signup bonus to close the gap.
+  Consider it if you already bank with Truist or want the 12 month runway;
+  otherwise there are better flat-rate options.

--- a/data/cards/truist-enjoy-cash-3-2-1.yaml
+++ b/data/cards/truist-enjoy-cash-3-2-1.yaml
@@ -65,13 +65,16 @@ benefits:
 apply_link: https://creditcard.digitalcommerce.truist.com/product/CR3
 page_check_url: https://www.truist.com/credit-cards/enjoy-cash
 our_take: >
-  Truist Enjoy Cash 3-2-1 covers a practical set of household bills: 3% back
-  on gas and EV charging, 2% on groceries and utilities, and no annual fee. It
-  also carries 12 months of 0% intro APR on both purchases and balance
-  transfers, plus no foreign transaction fees. The constraint is the cap:
-  those bonus categories share a combined $1,000 per month, roughly $12,000 a
-  year, and every dollar past it earns the 1% base rate. There is also no
-  signup bonus, so nothing accelerates the first year. If your gas, grocery,
-  and utility spending fits under $1,000 a month it is a reasonable no-fee
-  everyday card, particularly with a Truist deposit account to claim the 10%
-  to 50% redemption bonus, but heavier spenders will outgrow it quickly.
+  The 3-2-1 structure covers common household spending: 3% back on gas and EV
+  charging, 2% on groceries and utilities, and 1% on everything else, with no
+  annual fee and no foreign transaction fees. It also carries 0% intro APR for
+  12 months on both purchases and balance transfers, so it can double as a
+  short-term payoff card before the rate moves to 18.74% to 27.74%. The
+  constraint to understand is the cap: the 3% and 2% categories share a
+  combined $1,000 monthly limit, after which everything drops to 1%, so the
+  bonus rates are capped at roughly $360 a year even if you max them
+  perfectly. There is no signup bonus, which makes the Loyalty Cash Bonus the
+  main upside for Truist customers, adding 10% to 50% on rewards redeemed into
+  an eligible Truist deposit account depending on your combined balances. It
+  is a sensible no fee everyday card for a Truist depositor with moderate gas
+  and grocery spend, and unremarkable for anyone else.

--- a/data/cards/truist-enjoy-cash-secured.yaml
+++ b/data/cards/truist-enjoy-cash-secured.yaml
@@ -62,12 +62,15 @@ benefits:
     category: "security"
 apply_link: https://www.truist.com/credit-cards/enjoy-cash-secured
 our_take: >
-  Truist Enjoy Cash Secured actually pays rewards, which is unusual for a
-  credit-builder card: 3% back on gas and EV charging and 2% on groceries and
-  utilities, with no annual fee. Payment history reports monthly to all three
-  major credit bureaus, which is the real job this card is doing. Two limits
-  matter. The bonus categories share a combined $1,000 monthly cap before
-  everything drops to 1%, and the APR is a fixed 26.74% with no intro period,
-  so this only works if you pay the balance in full every month. Use it to
-  build history while earning something on gas and groceries, then move to an
-  unsecured card once your score supports one.
+  Most secured cards earn nothing, so a secured card paying 3% on gas and EV
+  charging and 2% on groceries and utilities is a genuinely useful option for
+  building credit, and there is no annual fee or foreign transaction fee.
+  Payment history is reported monthly to all three major credit bureaus, which
+  is the point of the card, and Truist depositors can add 10% to 50% to
+  rewards redeemed into an eligible deposit account depending on their
+  combined balances. Two limits matter. The 3% and 2% categories share a
+  combined $1,000 monthly cap before dropping to 1%, and the APR is a flat
+  26.74% with no intro period, so carrying a balance will cost far more than
+  the rewards return. Use it as a credit builder you pay in full every month,
+  earn what you can on gas and groceries along the way, and plan to graduate
+  to an unsecured card once your file supports it.

--- a/data/cards/truist-enjoy-travel.yaml
+++ b/data/cards/truist-enjoy-travel.yaml
@@ -48,14 +48,15 @@ benefits:
     category: "rewards"
 apply_link: https://www.truist.com/credit-cards/enjoy-travel
 our_take: >
-  Truist Enjoy Travel gets the basics right for a card with no annual fee: 2x
-  miles on airfare, hotels, and car rentals, no foreign transaction fees, and
-  an $85 Global Entry or TSA PreCheck credit once every four years that costs
-  nothing to keep. The 20,000-mile signup bonus after $1,500 in purchases in
-  three months is a low bar to clear. Outside those three travel categories
-  the card earns a flat 1x, so treat it as a supplement rather than the card
-  you run daily spending through. Redemption value also hinges on the Loyalty
-  Travel Bonus, which adds 10% to 50% depending on your Truist deposit
-  balances, so plan on the 10% tier unless you keep significant money with the
-  bank. For an occasional traveler who wants fee-free foreign spending and a
-  free Global Entry credit, it is a fair card to hold.
+  The Enjoy Travel earns 2 miles per dollar on airlines, hotels, and car
+  rentals with no annual fee and no foreign transaction fee, which is a
+  reasonable setup for occasional travelers who don't want to pay for the
+  privilege. The 20,000-mile signup bonus after $1,500 in three months is easy
+  to clear, and the up to $85 Global Entry or TSA PreCheck credit every four
+  years is unusual on a card that costs nothing to hold. The catch is that
+  everything outside those three travel categories earns just 1 mile per
+  dollar, so this is a supplement rather than a primary card. The Loyalty
+  Travel Bonus of 10% to 50% extra value on travel redemptions is the real
+  upside, but the tier depends on how much you keep in Truist deposit
+  accounts, so most people will see the low end. Worth carrying if you already
+  bank with Truist, less compelling if you don't.

--- a/data/cards/truist-future.yaml
+++ b/data/cards/truist-future.yaml
@@ -21,12 +21,13 @@ apr:
     max: 25.74
 apply_link: https://www.truist.com/credit-cards/future
 our_take: >
-  The Future is a straightforward balance-transfer card: 15 months of 0% intro
-  APR on both purchases and balance transfers, with no annual fee and no
-  foreign transaction fee. That window is shorter than the longest offers on
-  the market, but it is enough to clear a moderate balance or spread a large
-  purchase over a little more than a year. The tradeoff is that the card
-  carries no rewards program at all, so nothing accrues while you pay the
-  balance down and nothing keeps it useful afterward. Once the intro period
-  ends the rate resets to a variable 16.74% to 25.74%, so plan to be finished
-  before then. Open it for the 0% runway, not for anything ongoing.
+  The Future is a straightforward debt card: 0% intro APR for 15 months on
+  both purchases and balance transfers, with no annual fee and no foreign
+  transaction fee. That gives you a little over a year to pay down a balance
+  or spread out a large purchase before the regular 16.74% to 25.74% APR kicks
+  in. Be clear about what you're getting, though: this card earns no rewards
+  at all, so there is no cash back or points to justify keeping it in rotation
+  afterward. Fifteen months is also on the shorter side, since several
+  competing balance-transfer cards run 18 to 21 months. Open it if the 0%
+  window matches your payoff timeline, and plan on it going quiet once that
+  window closes.

--- a/data/cards/united-business.yaml
+++ b/data/cards/united-business.yaml
@@ -130,17 +130,18 @@ benefits:
     category: "travel"
     enrollment_required: false
 our_take: >
-  The pull here is the welcome offer: 100,000 miles after $5,000 in the first
-  three months, plus 2,000 Premier qualifying points and another 10,000 miles
-  for adding an employee card, against a $150 annual fee. The everyday earn is
-  built for a small business that travels, with 2x on United purchases, gas,
-  dining, office supplies, and local transit including rideshare, and
-  everything else at 1x. A stack of annual credits can cover the fee several
-  times over if you actually use them, including $125 in United credit after
-  five United flight purchases of $100 or more, up to $120 a year in Instacart
-  credits, $100 in rideshare credits, and $100 toward JSX flights. The catch
-  is how conditional that value is: several credits require enrollment, most
-  arrive in small monthly slices, and the Instacart credit is set to end after
-  December 31, 2027. If your spend is not United-heavy, the free first checked
-  bag, priority boarding, and two annual United Club passes are the real
-  reason to keep it.
+  The United Business is built around the everyday perks rather than the earn
+  rate: free first checked bag for you and a companion, priority boarding, two
+  United Club passes each year, and a stack of annual credits including $125
+  in United travel after five qualifying flight purchases, $100 toward
+  Renowned Hotels stays, $100 in rideshare credits, and $120 in Instacart
+  credits. The 100,000-mile signup bonus after $5,000 in three months, plus
+  2,000 Premier qualifying points and another 10,000 miles for adding an
+  employee card, is a strong opening for a $150 annual fee. Earning is where
+  it gets thinner: the 2x rate on airline spend applies only to United
+  purchases, and while gas, dining, office supplies, and transit also earn 2
+  miles per dollar, everything else sits at 1. The credits also come with
+  strings, since the rideshare and Instacart benefits require enrollment and
+  the Instacart perk is scheduled to end at the end of 2027. This works best
+  for a small business that flies United often enough to use the bag waiver
+  and lounge passes rather than one chasing raw earn rates.

--- a/data/cards/united-club-business.yaml
+++ b/data/cards/united-club-business.yaml
@@ -116,18 +116,18 @@ benefits:
     category: "travel"
     enrollment_required: false
 our_take: >
-  United Club All Access membership for the primary cardmember is the whole
-  argument for this card, and at a $695 annual fee it needs to be, with
-  employee cardholders getting four one-time passes a year plus first and
-  second free checked bags and Premier Access priority handling. Earning is
-  simple rather than rich: 2x on United purchases, 5x on hotels prepaid
-  through Renowned Hotels for United Cardmembers, and 1.5x on everything else,
-  which is a better base rate than most airline cards manage. The current
-  offer is 100,000 miles after $5,000 in three months, with 2,000 Premier
-  qualifying points and 10,000 more miles for adding an employee card. Credits
-  look generous on paper, up to $240 in Instacart credits plus an Instacart+
-  membership, $200 for Renowned Hotels stays, $200 for JSX, and $150 in
-  rideshare credits, but they arrive in monthly pieces, several need
-  enrollment, and the Instacart portion runs only through December 31, 2027.
-  Skip it unless you fly United often enough to live in the lounges, because
-  the membership is what you are really paying for.
+  The reason to carry this card is the United Club All Access membership for
+  the primary cardmember, which United values at over $750 on its own and
+  which comes with four one-time passes a year for employee cardholders.
+  Around that sit first and second checked bags free, Premier Access priority
+  handling, and roughly $940 in annual credits across Renowned Hotels,
+  rideshare, Instacart, Avis and Budget, JSX, and FareLock. The $695 annual
+  fee only makes sense if you actually spend time in United clubs, because the
+  earn structure is unremarkable: 2 miles per dollar is limited to United
+  purchases, 5x applies only to hotels prepaid through the Renowned Hotels
+  program, and everything else earns 1.5. The 100,000-mile signup bonus after
+  $5,000 in three months, plus 2,000 Premier qualifying points and 10,000 more
+  miles for an employee card, softens the first year considerably. Also note
+  that most of those credits need enrollment or fall in specific booking
+  channels, so the paper value is well above what a casual traveler will
+  realistically capture.

--- a/data/cards/united-club-infinite.yaml
+++ b/data/cards/united-club-infinite.yaml
@@ -117,17 +117,18 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/united/club-infini
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  United Club membership for the primary cardholder, companions included, is
-  the reason to carry this card, and it is why it wears the Best Premium badge
-  at number 13 on our Best Airline Credit Cards list even with a $695 annual
-  fee. Earning is front-loaded toward the airline: 5x on United purchases and
-  on hotels prepaid through Renowned Hotels for United Cardmembers, 2x on
-  dining and other travel, and just 1x on everything else. Chase trimmed the
-  welcome offer from 100,000 miles to 80,000 in May, still after $5,000 in
-  three months, with 10,000 more for adding an authorized user. The credits
-  can offset a large share of the fee if you use them, including up to $240 a
-  year in Instacart credits, $200 for Renowned Hotels, $200 for JSX, $150 in
-  rideshare, and up to $120 for Global Entry or TSA PreCheck every four years,
-  though most arrive monthly and several require opting in. If lounge access
-  is not worth roughly the price of the fee to you on its own, a cheaper
-  United card covers the bags and boarding for far less.
+  Chase recently cut the signup bonus here from 100,000 miles to 80,000 after
+  $5,000 in three months, with another 10,000 miles for adding an authorized
+  user, so the opening offer is weaker than it was in the spring. What still
+  carries the card is United Club membership for the primary cardholder
+  including eligible companions, two free checked bags, Premier Access, and
+  1,500 Premier qualifying points a year plus 1 PQP per $15 spent up to
+  28,000. Earning is decent at the top with 5 miles per dollar on United
+  purchases and on hotels prepaid through the Renowned Hotels program, plus 2x
+  on dining and other travel, though everything else is a flat 1. The $695
+  annual fee is only defensible if you use the lounge access regularly, since
+  the annual credits that pad the value, $200 for Renowned Hotels, $150
+  rideshare, $240 Instacart, $200 JSX, and $100 for Avis or Budget, are narrow
+  and mostly require opting in. It sits at #14 on our Best Airline Credit
+  Cards list with a Best Premium badge, which is roughly where a lounge-first
+  card belongs: right for frequent United flyers, expensive for everyone else.

--- a/data/cards/united-explorer.yaml
+++ b/data/cards/united-explorer.yaml
@@ -113,16 +113,17 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-expl
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Explorer is the sensible middle of United's lineup: $150 a year buys a
-  free first checked bag, priority boarding, two United Club one-time passes,
-  and up to $120 back on Global Entry or TSA PreCheck every four years. Chase
-  cut the welcome offer from 60,000 miles to 50,000 in May, now after $3,000
-  in three months, with 10,000 more for adding an authorized user. Earning is
-  narrow, at 3x on eligible United purchases, 2x on dining and hotels, and 1x
-  on everything else, so this is not the card for general spending. The
-  smaller credits can still cover the fee, including $100 a year for prepaid
-  United Hotels stays, $10 a month at Instacart through December 31, 2027,
-  $100 for JSX, and $60 in rideshare, but they come in monthly pieces and some
-  require opting in. It ranks tenth on our Best Airline Credit Cards list, and
-  for most people the free checked bag alone justifies the fee if you fly
-  United a couple of times a year.
+  The Explorer is the middle-of-the-road United card and the one that makes
+  sense for most people who fly United a handful of times a year: free first
+  checked bag, priority boarding, two United Club passes annually, and up to
+  $120 back for Global Entry, TSA PreCheck, or NEXUS every four years, all for
+  a $150 annual fee. Chase trimmed the signup bonus from 60,000 miles to
+  50,000 in May, still after $3,000 in three months with 10,000 more for
+  adding an authorized user, so the offer is softer than it was but not thin.
+  Earning is modest: 3 miles per dollar applies only to eligible United
+  purchases, dining and hotels earn 2, and everything else is 1. The annual
+  credits, up to $100 on United Hotels, $60 in rideshare, $50 in Avis or
+  Budget TravelBank cash, $120 Instacart, and $100 on JSX, look good on paper
+  but are tied to specific booking channels and monthly caps. It ranks #10 on
+  our Best Airline Credit Cards list, and the checked-bag waiver alone covers
+  the fee for a couple that flies United twice a year.

--- a/data/cards/united-gateway.yaml
+++ b/data/cards/united-gateway.yaml
@@ -40,18 +40,19 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-gate
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Gateway is United's no-annual-fee entry point and our Best No-Fee pick
-  among airline cards, sitting at number 17 on that list. You get 2x on
-  eligible United purchases, gas, and local transit, 1x on everything else,
-  and 30,000 bonus miles after just $1,000 in three months, plus 10,000 more
-  for adding an authorized user, which is an unusually low bar. It also
-  includes 12 months of 0% intro APR on purchases, rare for an airline card,
-  before the rate resets to a variable 19.74% to 28.24%. Be clear on the
-  limits: there is no free checked bag or lounge access out of the gate, and
-  the perks that exist, two checked bags and 10% off award flights, only
-  unlock after $10,000 of spend in a calendar year. Treat it as a free way to
-  keep MileagePlus miles accruing, not as a card that improves the flight
-  itself.
+  The Gateway is the no-annual-fee entry point to United miles, earning 2
+  miles per dollar on eligible United purchases, gas, and transit, with 1 on
+  everything else and no foreign transaction fee. The 30,000-mile signup bonus
+  after just $1,000 in three months, plus 10,000 more for adding an authorized
+  user, is a low bar for a free card, and the 12-month 0% intro APR on
+  purchases gives it a second use. Be honest about what it doesn't have: no
+  free checked bag, no lounge passes, and no Global Entry credit, so the perks
+  that make the paid United cards worthwhile are absent here. The two benefits
+  it does offer, two free checked bags and 10% off award flights, only unlock
+  after $10,000 in calendar-year spend, which is a lot to put on a 1x base
+  card. It carries the Best No-Fee badge at #17 on our Best Airline Credit
+  Cards list, and that is the right framing: a way to keep earning United
+  miles without paying to do it, not a card to build a wallet around.
 benefits:
   - name: "Checked Bags"
     value: 0

--- a/data/cards/united-quest.yaml
+++ b/data/cards/united-quest.yaml
@@ -134,18 +134,19 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/united/united-ques
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Quest's case rests on its $200 annual United TravelBank credit,
-  deposited after account opening and again each anniversary, plus two free
-  checked bags, which together take a real bite out of the $350 fee for anyone
-  who flies United. Earning is strong on the airline: 4x on United purchases,
-  5x on hotels prepaid through Renowned Hotels for United Cardmembers, 2x on
-  other travel, dining, and select streaming, and 1x on everything else. Chase
-  cut the welcome offer sharply in May, from 90,000 miles to 60,000 after
-  $4,000 in three months, so while it still ranks eleventh on our signup bonus
-  list, it is a much weaker entry point than it was. Anniversary extras add up
-  if you use them, including a 10,000-mile award flight discount each year,
-  $150 for Renowned Hotels, $150 for JSX, $180 in Instacart credits through
-  2027, and up to $120 for Global Entry every four years. The catch is that
-  most of that value is United-specific or arrives as small monthly credits,
-  so if you fly the airline only occasionally, the cheaper Explorer covers the
-  bag and boarding for less.
+  The Quest sits between the Explorer and the Club cards and justifies its
+  $350 annual fee mostly through the $200 in United TravelBank cash deposited
+  after account opening and each anniversary, plus a 10,000-mile award flight
+  discount every year. Add two free checked bags, up to $120 for Global Entry,
+  TSA PreCheck, or NEXUS, and 1,000 Premier qualifying points a year, and the
+  fixed value is real if you fly United. Earning is the strongest of the
+  mid-tier United cards, with 4 miles per dollar on United purchases, 5x on
+  hotels prepaid through the Renowned Hotels program, and 2x on other travel,
+  dining, and select streaming, though everything else stays at 1. The main
+  caveat is the signup bonus, which Chase cut from 90,000 miles to 60,000 in
+  May; it still comes after $4,000 in three months with 10,000 more for an
+  authorized user, but this is not the offer it was, even though the card
+  still shows up at #12 on our Best Credit Card Signup Bonuses list. It also
+  ranks #6 on our Best Airline Credit Cards list, and the extra credits for
+  Renowned Hotels, rideshare, Instacart, JSX, and car rentals are best treated
+  as bonuses you may or may not use rather than fee offsets you can count on.

--- a/data/cards/us-bank-altitude-connect.yaml
+++ b/data/cards/us-bank-altitude-connect.yaml
@@ -66,17 +66,18 @@ apply_link: https://www.usbank.com/credit-cards/altitude-connect-visa-signature-
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Altitude Connect charges no annual fee yet still includes up to $100
-  back on Global Entry or TSA PreCheck every five years and a complimentary
-  12-month Priority Pass Select membership, which is rare at this price. The
-  earn structure is broad too: 5x on hotels and car rentals prepaid through
-  the U.S. Bank travel portal, 4x on travel and on gas including EV charging,
-  2x on groceries, dining, and streaming, and 1x on everything else. Two
-  details are worth knowing before you apply: the 4x gas rate is capped at
-  $1,000 per quarter and falls to 1x above that, and the lounge membership is
-  specified as 12 months rather than ongoing. The 20,000-point welcome bonus
-  after $1,000 in three months is modest but easy to reach, and 15 months of
-  0% intro APR on both purchases and balance transfers gives the card a second
-  life as a payoff tool. With no foreign transaction fee, it holds up as a
-  single travel card for someone who does not want to pay for a premium one.
+  The Altitude Connect packs an unusual amount into a card with no annual fee:
+  4 points per dollar on travel and on gas including EV charging, 5x on hotels
+  and car rentals booked through the U.S. Bank travel portal, and 2x on
+  groceries, dining, and streaming. It also carries a Priority Pass Select
+  membership for airport lounge access and up to $100 back for Global Entry or
+  TSA PreCheck every five years, benefits usually reserved for cards that
+  charge for them. Read the fine print on the headline rate, though: the 4x on
+  gas is capped at $1,000 per quarter and drops to 1 point per dollar after
+  that, and the lounge membership is a 12-month benefit rather than an
+  open-ended one. The 20,000-point signup bonus after $1,000 in three months
+  is modest but easy, and the 15-month 0% intro APR on purchases and balance
+  transfers plus no foreign transaction fee round it out. For a fee-free
+  travel card this is a lot of coverage, as long as you treat the caps as real
+  limits.
 

--- a/data/cards/us-bank-altitude-go-visa-signature.yaml
+++ b/data/cards/us-bank-altitude-go-visa-signature.yaml
@@ -49,19 +49,19 @@ apply_link: https://www.usbank.com/credit-cards/altitude-go-visa-signature-credi
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Altitude Go earns 4x points on dining on up to $2,000 per quarter with
-  no annual fee, which is what earns it the Best No Annual Fee badge at number
-  6 on our dining and groceries list. Beyond restaurants, 2x on groceries,
-  gas, and streaming and 1x on everything else make it a workable single card
-  for everyday spending, and there is a $15 annual streaming credit if you
-  enroll and keep 11 months of streaming activity. Watch the cap, though:
-  dining drops to 1x once you pass $2,000 in a quarter, so heavy restaurant
-  spenders will outgrow the headline rate. The 20,000-point bonus after $1,000
-  in three months is easy to earn, and 15 billing cycles of 0% intro APR
-  covers purchases and balance transfers made within 60 days of opening, with
-  a 5% transfer fee. The one real mismatch with its ninth-place spot on our
-  travel list is that this card does charge foreign transaction fees, so leave
-  it home when you go abroad.
+  The Altitude Go earns 4 points per dollar on dining, which is a strong rate
+  for a card with no annual fee, plus 2x on groceries, gas, and streaming and
+  1x on everything else. That dining rate is capped at $2,000 per quarter and
+  falls to 1 point after that, so it suits someone spending a few hundred
+  dollars a month on restaurants rather than a heavy entertainer. A
+  20,000-point signup bonus after $1,000 in three months and 15 billing cycles
+  of 0% intro APR on purchases and balance transfers give it a useful first
+  year, though the balance transfer must happen within 60 days and carries a
+  5% fee. The one real drawback is the foreign transaction fee, which makes it
+  a poor travel companion despite its #9 spot with a Best for Beginners badge
+  on our Best Travel Credit Cards list. It also ranks #6 on our Best Credit
+  Cards for Dining and Groceries list, and that is where it belongs: a simple
+  domestic dining card with a small $15 annual streaming credit as a bonus.
 benefits:
   - name: "Streaming Service Credit"
     value: 15

--- a/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
+++ b/data/cards/us-bank-altitude-reserve-visa-infinite.yaml
@@ -8,16 +8,17 @@ annual_fee: 400
 reward_type: "points"
 network: "visa"
 our_take: >
-  U.S. Bank is no longer accepting applications for the Altitude Reserve, so
-  this is a card to evaluate only if you already hold one. Its signature
-  feature is the $325 annual travel credit, which applies to travel purchases
-  made with a mobile wallet, meaning you have to pay through Apple Pay or a
-  similar wallet for it to trigger. Add unlimited Priority Pass Select lounge
-  access and up to $100 back on Global Entry or TSA PreCheck every five years,
-  and the $400 annual fee is close to covered for anyone who travels
-  regularly. If you use the travel credit each year, keeping the card is an
-  easy call. If you do not, understand that closing it is permanent, since
-  there is no way to reapply.
+  The Altitude Reserve is no longer accepting applications, so this is a card
+  you can only keep, not open. For existing holders the math still works if
+  you use the benefits: a $325 annual travel credit, up to $100 back for
+  Global Entry or TSA PreCheck every five years, and unlimited Priority Pass
+  Select lounge access against a $400 annual fee. The important condition is
+  that the travel credit applies to travel purchases made through a mobile
+  wallet, so you need to be paying with Apple Pay or a similar wallet at
+  checkout for it to trigger. If you are already in the habit, the credit
+  alone covers most of the fee and the lounge access is close to pure upside.
+  If you aren't, or if you rarely travel, the $400 is harder to justify and
+  there is no way back in once you close it.
 benefits:
   - name: "Annual Travel Credit"
     value: 325

--- a/data/cards/us-bank-cash-plus-visa-signature.yaml
+++ b/data/cards/us-bank-cash-plus-visa-signature.yaml
@@ -52,16 +52,18 @@ apply_link: https://www.usbank.com/credit-cards/cash-plus-visa-signature-credit-
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Cash+ gives you more control over your 5% than almost any no-annual-fee
-  card: you pick two categories each quarter from a list that includes fast
-  food, streaming, home utilities, cell phone providers, department stores,
-  and gyms, earning 5% on up to $2,000 in combined spend before the rate drops
-  to 1%. You also choose one everyday category at 2%, either groceries and
-  grocery delivery, gas and EV charging, or restaurants, and prepaid travel
-  booked through the U.S. Bank Travel Rewards Center earns 5%. The tradeoff is
-  the upkeep: you have to re-select categories every quarter, and if you
-  forget, everything outside your last picks falls to the 1% base rate. The
-  signup bonus recently came back down to $200 after $1,000 in the first three
-  months, having briefly sat at $250 earlier this year. There's also a 0%
-  intro APR for 15 months on purchases and balance transfers, though foreign
-  transaction fees make this one to leave home when you travel abroad.
+  The Cash+ is the most flexible of the rotating-category cash back cards
+  because you pick the categories yourself: 5% back on two chosen categories
+  from a list that includes home utilities, cell phone providers, streaming,
+  department stores, and gyms, on up to $2,000 in combined quarterly spend,
+  plus 2% on one everyday category you choose from groceries, gas, or
+  restaurants. That control is the real advantage, since you can point the 5%
+  at bills you already pay rather than hoping a rotating calendar matches your
+  life. The tradeoffs are that you have to remember to select categories each
+  quarter, spending past the $2,000 quarterly cap drops to 1%, and the card
+  charges a foreign transaction fee. U.S. Bank also cut the signup bonus from
+  $250 to $200 in early August, still after $1,000 in three months, so the
+  opening offer is a bit weaker than it was. With no annual fee and 15 months
+  of 0% intro APR on purchases and balance transfers, it is still a strong
+  domestic cash back pick for anyone willing to manage the quarterly
+  selection.

--- a/data/cards/us-bank-secured.yaml
+++ b/data/cards/us-bank-secured.yaml
@@ -5,15 +5,16 @@ image: "us-bank-secured.png"
 accepting_applications: true
 apply_link: https://www.usbank.com/credit-cards/secured-visa-credit-card.html
 our_take: >
-  The U.S. Bank Secured Visa is a straightforward credit-building tool: no
-  annual fee, so the only money at stake is the refundable deposit backing
-  your line. That keeps the cost of rebuilding at zero, and it's why the card
-  lands at #5 on our Best Secured Credit Cards list. Be clear about what
-  you're not getting, though: there are no rewards of any kind, no intro APR,
-  and the ongoing rate is a flat 27.49%, so this card only makes sense if you
-  pay in full every month. It also charges foreign transaction fees, which
-  rules it out for travel. Use it to establish a payment history, then move on
-  to a rewards card once your score supports one.
+  The appeal here is simplicity: a secured card from a major issuer with no
+  annual fee, which is why it lands at #5 on our list of the best secured
+  cards. What you give up is everything else: there are no rewards at all, and
+  the regular APR is a flat 27.49%, so carrying a balance gets expensive fast.
+  The foreign transaction fee also rules it out for travel, which is a shame
+  given how often people rebuilding credit are told to keep spending small and
+  predictable. Treat it as a credit-building tool rather than a spending card:
+  put one small recurring charge on it, pay in full every month, and let the
+  on-time history do the work. Once your score supports an unsecured card,
+  there is little reason to keep it open.
 annual_fee: 0
 category: "secured"
 tags:

--- a/data/cards/us-bank-shield.yaml
+++ b/data/cards/us-bank-shield.yaml
@@ -27,18 +27,18 @@ apply_link: https://www.usbank.com/credit-cards/pm/shield-visa-credit-card.html
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Shield's whole pitch is time: 21 months of 0% intro APR on both
-  purchases and balance transfers, with no annual fee, which is why it sits at
-  #1 on our Best 0% APR Credit Cards list. That's nearly two years to pay down
-  existing debt or spread out a large purchase before the regular 16.99% to
-  27.99% APR kicks in. The catch is that the rewards are close to nonexistent:
-  4% back on prepaid air, hotel, and car reservations booked through the U.S.
-  Bank Travel Rewards Center is the only earn rate, so there's no reason to
-  put everyday spending here. A $20 annual statement credit for 11 consecutive
-  months of purchases and cell phone protection worth up to $600 per claim are
-  pleasant extras, not reasons to apply. Open it for the interest-free runway,
-  make a payoff plan that finishes inside 21 months, and expect to pair it
-  with a real rewards card afterward.
+  Twenty-one months of 0% intro APR on both purchases and balance transfers,
+  with no annual fee, is about as long a runway as you will find, and it is
+  why the Shield sits at the top of our best 0% APR list. That makes it a
+  strong fit if you are paying down existing debt or spreading a large
+  purchase over nearly two years, with a regular APR of 16.99% to 27.99%
+  waiting on the other side. The catch is the rewards: outside of 4% back on
+  prepaid air, hotel, and car reservations booked through the U.S. Bank Travel
+  Rewards Center, there is no everyday earn rate at all. The $20 annual
+  statement credit for 11 consecutive months of purchases and cell phone
+  protection up to $600 per claim are minor extras, and the foreign
+  transaction fee keeps this card at home. Open it for the intro window, run
+  your payoff plan, and expect to move on once it closes.
 benefits:
   - name: "Annual Statement Credit"
     value: 20

--- a/data/cards/us-bank-shopper.yaml
+++ b/data/cards/us-bank-shopper.yaml
@@ -70,19 +70,18 @@ benefits:
     category: "telecom"
     enrollment_required: false
 our_take: >
-  The Shopper Cash Rewards stopped accepting new applications in July 2026, so
-  this is now a card to evaluate only if you already hold one. Its draw was 6%
-  back at two retailers you picked each quarter from a set list including
-  Amazon, Apple, Costco, Target, and Walmart, capped at $1,500 in combined
-  spend before dropping to 1.5%, plus 3% on one everyday category, gas,
-  wholesale clubs, or utilities, up to another $1,500. Note that the 6% only
-  applies at the specific retailers you select, not to online shopping
-  generally. If you're still carrying it, the math turns on the $95 annual fee
-  that arrives after the first-year waiver: maxing both quarterly caps is
-  worth well more than the fee, but a light quarter or a forgotten selection
-  leaves you with a 1.5% card that costs $95. Cell phone protection of up to
-  $600 per claim when you pay your bill with the card is the one perk worth
-  keeping in mind.
+  U.S. Bank stopped accepting applications for the Shopper Cash Rewards in
+  July 2026, so this is now a card you can keep but not open. If you already
+  carry one, the value is concentrated in the 6% rate at two retailers you
+  choose each quarter, which earns only at those chosen merchants and only on
+  the first $1,500 combined before dropping to 1.5%. Around that sit 3% on one
+  everyday category you pick each quarter, also capped at $1,500, 5.5% on
+  hotel and car reservations booked in the Travel Center, and 1.5% on
+  everything else. All of it has to clear a $95 annual fee once the first-year
+  waiver ends, which means using both quarterly picks consistently rather than
+  letting the card sit. If you are looking for a replacement, the Blue Cash
+  Everyday, U.S. Bank Cash+, and Wells Fargo Active Cash each cover part of
+  what this card did without the fee.
 apply_link: https://www.usbank.com/credit-cards/shopper-cash-rewards-visa-signature-credit-card.html
 foreign_transaction_fee: true
 network: "visa"

--- a/data/cards/us-bank-smartly-visa-signature.yaml
+++ b/data/cards/us-bank-smartly-visa-signature.yaml
@@ -5,16 +5,17 @@ image: "smartly-signature.png"
 accepting_applications: true
 apply_link: https://www.usbank.com/credit-cards/bank-smartly-visa-signature-credit-card.html
 our_take: >
-  The Smartly is a simple flat-rate card: 2% back on everything with no annual
-  fee and nothing to select or track. That puts it a half point ahead of the
-  common 1.5% cards and makes it a reasonable default for spending that
-  doesn't fall into a bonus category. It also comes with 12 months of 0% intro
-  APR on purchases and balance transfers, a shorter runway than dedicated
-  balance-transfer cards but useful if you're financing something modest. Two
-  things hold it back: there's no signup bonus to sweeten the first year, and
-  it charges foreign transaction fees, so it should stay home on international
-  trips. Treat it as a catch-all backup rather than the centerpiece of a
-  wallet.
+  A flat 2% cash back on every purchase with no annual fee is the whole pitch,
+  and it is a clean one: nothing to activate, no categories to rotate, no
+  quarterly picks to remember. The 12 months of 0% intro APR on both purchases
+  and balance transfers adds a modest runway if you have something to pay
+  down, though it is roughly half the length of what the longest 0% cards
+  offer. Two things keep it from being a default: the foreign transaction fee
+  makes it a poor travel companion, and a regular APR of 18.24% to 28.24%
+  means 2% back is meaningless if you carry a balance. There is no signup
+  bonus either, so the value accrues slowly through everyday spending rather
+  than arriving up front. It works best as a base card for domestic purchases
+  that do not earn a bonus anywhere else in your wallet.
 category: "cashback"
 annual_fee: 0
 reward_type: "cashback"

--- a/data/cards/us-bank-split.yaml
+++ b/data/cards/us-bank-split.yaml
@@ -12,15 +12,15 @@ foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
   The Split's one real feature is its payment structure: any purchase of $100
-  or more can be paid over three months with no interest and no fees, and
-  there's no annual fee to hold the card. That's a genuinely useful way to
-  smooth out a mid-sized expense without the plan fees most buy-now-pay-later
-  products attach. The problem is that this is all the card does. It earns no
-  rewards, has no signup bonus, and carries foreign transaction fees, so
-  there's no reason to spend on it outside of purchases you actually want to
-  split. If you're mainly after breathing room on a large purchase, a card
-  with a long 0% intro APR window gives you far more time to pay it off. Keep
-  this one narrow: use it for the three-month plans and nothing else.
+  or more can be broken into a 3-month plan with no interest and no fees, and
+  the card itself carries no annual fee. That makes it a narrow but honest
+  tool if you want to spread out mid-size purchases without paying financing
+  charges. Be clear about what is missing, though: the card earns no rewards
+  of any kind, so every dollar you route through it is a dollar not earning
+  cash back or points elsewhere. It also charges foreign transaction fees,
+  which takes it out of contention for anything abroad. Use it deliberately
+  for the purchases you actually want stretched across three months, and keep
+  a rewards card for everything else.
 benefits:
   - name: "3-Month Interest-Free Plans"
     value: 0

--- a/data/cards/usaa-cashback-rewards-plus.yaml
+++ b/data/cards/usaa-cashback-rewards-plus.yaml
@@ -36,15 +36,15 @@ apr:
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  This is one of the few cards that pays a bonus rate on military base
-  purchases, 5% on the first $5,000 each year, alongside 5% on gas and 3% on
-  groceries, each capped at $3,000 annually. For a household that fills up
-  regularly and shops on base, those caps are worth real money on a card with
-  no annual fee and no foreign transaction fees. Past the caps and everywhere
-  else the rate falls to 1%, which is below what a basic flat-rate card pays,
-  so this works best as a category card rather than your only one. There's
-  also a 0% intro APR on balance transfers running through the March 2028
-  billing cycle for transfers that post by November 30, 2026, but the 5%
-  transfer fee eats into the savings on a large balance. Note that it runs on
-  the Amex network, so acceptance is narrower than a Visa or Mastercard, which
-  matters most for gas stations abroad.
+  If your spending clusters on or near a military base, this is the strongest
+  card in USAA's cash back lineup: 5% back on base purchases on the first
+  $5,000 each year, plus 5% on gas on the first $3,000 and 3% at grocery
+  stores on the same $3,000 cap. There is no annual fee and no foreign
+  transaction fee, which matters for anyone stationed overseas. The caps are
+  the real limit: once you clear them everything falls to the 1% base rate, so
+  the card's annual ceiling is a few hundred dollars rather than open-ended.
+  USAA is also running a 0% intro APR on balance transfers through the March
+  2028 billing cycle for transfers that post by November 30, 2026, though the
+  5% transfer fee takes a meaningful bite out of that. One practical note: it
+  runs on the Amex network rather than Visa, so confirm the merchants you use
+  most will take it.

--- a/data/cards/usaa-eagle-navigator.yaml
+++ b/data/cards/usaa-eagle-navigator.yaml
@@ -29,19 +29,19 @@ apr:
     min: 18.40
     max: 26.65
 our_take: >
-  The Eagle Navigator earns 2 points per dollar on everything, which is a
-  strong floor for a $95 travel card, and 3 points on travel plus transit
-  including rideshare and tolls. Add the annual 10,000 bonus points for
-  booking a hotel stay or car rental through the USAA Rewards Center and the
-  fee is largely covered before you count anything else, with a $120 Global
-  Entry or TSA PreCheck credit every four years on top. No foreign transaction
-  fees make it a reasonable card to take abroad, and the signup bonus is
-  30,000 points after $3,000 in the first three months. Active duty service
-  members get the annual fee waived entirely plus a reduced APR under the
-  Servicemembers Civil Relief Act, which changes the math considerably in
-  their favor. The limitation is flexibility: points run through USAA's own
-  rewards program, so you won't get the transfer-partner options that larger
-  travel programs offer.
+  The Eagle Navigator earns 2 points per dollar on everything and 3 on travel
+  and transit, including rideshare and tolls, with no foreign transaction fee,
+  which makes it a workable single-card setup for someone who travels
+  regularly. The 30,000 point signup bonus after $3,000 of spending in three
+  months and the up to $120 Global Entry or TSA PreCheck credit give the first
+  year a real head start against the $95 annual fee. Keeping it worthwhile
+  after that depends on the 10,000 bonus points awarded each year for booking
+  a hotel stay or car rental through the USAA Rewards Center, so you have to
+  route at least one booking through USAA annually to stay ahead. Active duty
+  members get the best version of this card: no annual fee while serving, plus
+  a reduced APR under the Servicemembers Civil Relief Act. If you are not
+  active duty and will not use the Rewards Center, a flat 2x base rate is
+  available elsewhere without a fee.
 benefits:
   - name: "Global Entry / TSA PreCheck Credit"
     value: 120

--- a/data/cards/usaa-preferred-cash-rewards.yaml
+++ b/data/cards/usaa-preferred-cash-rewards.yaml
@@ -15,16 +15,15 @@ rewards:
     value: 1.5
     unit: percent
 our_take: >
-  The Preferred Cash Rewards is a no-decisions card: a flat 1.5% back on
-  everything, no annual fee, and no foreign transaction fees, which is unusual
-  at this tier and makes it easy to take overseas. The $250 bonus after $1,000
-  in the first three months is generous relative to the spend required, so the
-  first year pays out well above the headline rate. The catch is the rate
-  itself: 1.5% is now the low end for flat-rate cards, and a 2% option will
-  out-earn it on every dollar after the bonus is banked. There's no intro APR
-  either, so it does nothing for existing debt, and the regular rate runs from
-  15.4% to 27.4%. Reasonable as a simple travel-friendly backup, less so as
-  the card you route most of your spending through.
+  The draw is the $250 cash bonus after $1,000 of spending in the first three
+  months, a low bar for a card that charges no annual fee. After that it
+  settles into a flat 1.5% back on everything, with nothing to activate or
+  track. The honest problem is that 1.5% now trails the 2% flat-rate cards
+  that have become common, so the ongoing earn rate is the weakest part of the
+  package. Where it does stand out is abroad: there is no foreign transaction
+  fee, and the regular APR starts at 15.4%, lower than most cash back cards if
+  you occasionally carry a balance. Worth opening for the bonus and the
+  overseas use, less compelling as the card you reach for every day.
 signup_bonus:
   value: 250
   type: cash

--- a/data/cards/usaa-rate-advantage.yaml
+++ b/data/cards/usaa-rate-advantage.yaml
@@ -18,14 +18,14 @@ apr:
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Rate Advantage is built around its regular APR, which starts at 10.4%
-  and tops out at 24.4%, a meaningfully lower ceiling than most cards offer,
-  and it charges no annual fee. That makes it one of the better options if you
-  expect to carry a balance occasionally rather than pay in full every month.
-  It also runs a 0% intro APR on balance transfers through the March 2028
-  billing cycle for transfers that post by November 30, 2026, though the 5%
-  transfer fee means a $5,000 balance costs $250 up front. What you give up is
-  everything else: there are no rewards at all, no signup bonus, and no intro
-  APR on purchases, so new spending starts accruing interest right away at the
-  ongoing rate. No foreign transaction fees is a small bonus. This is a
-  debt-management card, and it should be judged only on that.
+  The Rate Advantage is built around one number: a regular APR that starts at
+  10.4%, unusually low and the main reason to carry it if you sometimes
+  revolve a balance. On top of that sits a 0% intro APR on balance transfers
+  running through the March 2028 billing cycle for transfers posting by
+  November 30, 2026, though the 5% transfer fee is worth doing the math on
+  before you move a smaller balance. There is no annual fee and no foreign
+  transaction fee, so the card costs nothing to keep. The tradeoff is
+  absolute: it earns no rewards at all, meaning there is no cash back or
+  points to justify spending on it once your balance is clear. Think of it as
+  a low-cost place to park debt, not a card that competes for everyday
+  purchases.

--- a/data/cards/usaa-rewards.yaml
+++ b/data/cards/usaa-rewards.yaml
@@ -25,15 +25,14 @@ apr:
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The USAA Rewards card's appeal is a low-friction rewards setup: 2 points per
-  dollar on dining and gas, 1 point on everything else, no annual fee, and no
-  foreign transaction fees. The regular APR range starts at 13.4%, which is
-  unusually low for a rewards card, so it holds up better than most if you
-  occasionally carry a balance. The tradeoff is ambition: 2x on two categories
-  is a modest ceiling next to no-fee cards that pay more broadly, and there is
-  no signup bonus or intro APR offer to sweeten the first year. Think of it as
-  a steady everyday card for dining and fuel rather than a card that will
-  maximize your return. If you want the highest earn rate on those categories,
-  look elsewhere; if you want a simple, cheap card to keep long term, it does
-  the job.
+  USAA Rewards keeps things simple: 2 points per dollar on dining and gas, 1
+  point on everything else, no annual fee, and no foreign transaction fee.
+  That last piece is the quiet strength, since plenty of no-fee rewards cards
+  still charge 3% on purchases abroad. A regular APR starting at 13.4% is also
+  on the low end for a rewards card, which helps if a balance occasionally
+  rolls over. What is missing is a reason to choose it over the field: there
+  is no signup bonus, and 2x on two categories is modest next to cards paying
+  3% or more on dining. It is a reasonable card to keep alongside others,
+  especially for travel overseas, but it is not the one that should carry most
+  of your spending.
 

--- a/data/cards/usaa-secured-american-express.yaml
+++ b/data/cards/usaa-secured-american-express.yaml
@@ -15,13 +15,13 @@ apr:
 foreign_transaction_fee: false
 network: "amex"
 our_take: >
-  This is a straightforward credit-building tool: a secured Amex with no
-  annual fee, so the only money you tie up is the deposit itself. The lack of
-  a fee matters more than it sounds, because many secured cards charge one on
-  top of the security deposit, and here your cost of building history is
-  effectively zero if you pay in full. No foreign transaction fees is a
-  genuine bonus at this tier, making it usable on a trip abroad. The catch is
-  that it earns no rewards at all and the APR is fixed at 26.4%, so carrying a
-  balance is expensive and there is nothing to keep you engaged once your
-  credit improves. Use it to establish a payment record, then move to a card
-  that actually pays you back.
+  This is a straightforward credit-building card: no annual fee, no foreign
+  transaction fee, and a secured structure that makes approval far more
+  attainable than an unsecured card. Skipping the foreign transaction fee is
+  genuinely unusual at this end of the market, so it holds up if you are
+  traveling or stationed overseas while rebuilding. The tradeoffs are what you
+  would expect: no rewards at all, and a 26.4% regular APR that makes any
+  carried balance costly, though the point of a card like this is to pay in
+  full every month regardless. It also runs on the Amex network rather than
+  Visa, so acceptance is narrower at some merchants. Use it to build payment
+  history, then move on to a rewards card once your credit supports one.

--- a/data/cards/usaa-secured-visa-platinum.yaml
+++ b/data/cards/usaa-secured-visa-platinum.yaml
@@ -15,13 +15,13 @@ apr:
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The standout number here is the APR: 11.4% to 21.4% regular, which is
-  dramatically lower than the rates most secured cards carry, and that makes
-  this a rare credit-builder that will not punish you severely for an
-  occasional carried balance. There is no annual fee and no foreign
-  transaction fee, so the deposit is the only real cost of holding it. What
-  you give up is rewards: the card earns nothing, so every dollar of spending
-  buys you credit history and nothing more. That is a fair trade while you are
-  establishing a track record, but it gives you no reason to keep the card in
-  rotation afterward. Treat it as a low-cost stepping stone and plan to
-  graduate to a rewards card once your score supports one.
+  The standout here is the rate: a regular APR of 11.4% to 21.4% is remarkably
+  low for a secured card, a category where mid-20s pricing is the norm. Pair
+  that with no annual fee and no foreign transaction fee and you get an
+  unusually cheap way to build or rebuild credit, including while traveling or
+  stationed abroad. The catch is that it earns nothing: no rewards, no signup
+  bonus, and no ongoing perks, so it is a tool rather than a card you would
+  keep for its value. The playbook is the standard one: charge a small
+  recurring bill, pay it in full every month, and let the payment history
+  accumulate. Once your credit supports an unsecured rewards card, graduate
+  and put your deposit back to work.

--- a/data/cards/venmo-credit-card.yaml
+++ b/data/cards/venmo-credit-card.yaml
@@ -49,15 +49,17 @@ apply_link: https://venmo.com/about/creditcard
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Venmo card's draw is that it adapts to you: 3% back on your
-  highest-spend eligible category each statement period and 2% on the second
-  highest, drawn from a list of eight that covers transportation, travel,
-  groceries, entertainment, dining, bills and utilities, health and beauty,
-  and gas. That automatic sorting means you never have to activate or track
-  categories, which suits people whose spending shifts month to month.
-  Everything outside those two categories earns 1%, so the base rate is
-  ordinary, and cards that pay a flat 2% on all purchases can easily beat this
-  if your spending is spread thin. There is no signup bonus and no intro APR
-  window, and the regular APR runs 18.74% to 30.74%, so this is only worth it
-  if you pay in full. No annual fee and no foreign transaction fee keep the
-  cost of holding it at zero.
+  The Venmo card's draw is that it picks your bonus categories for you: 3%
+  back on whichever of eight eligible categories you spend the most in each
+  statement period, 2% on the runner-up, and 1% on everything else, with no
+  annual fee and no foreign transaction fee. The eligible list covers most of
+  a normal budget, including transportation, travel, groceries, dining,
+  entertainment, bills and utilities, health and beauty, and gas, so the top
+  tier usually lands somewhere useful without any quarterly activation. The
+  catch is that only two categories earn a bonus at a time and everything
+  outside them drops to 1%, which is below what a flat-rate 2% card would pay
+  on the same spending. There is no signup bonus here either, so nothing
+  offsets the slow start, and the regular APR runs from 18.74% to 30.74% with
+  no intro period to lean on. It suits someone whose spending is concentrated
+  and who wants rewards handled automatically, not someone chasing a headline
+  rate.

--- a/data/cards/wells-fargo-active-cash.yaml
+++ b/data/cards/wells-fargo-active-cash.yaml
@@ -32,18 +32,17 @@ apply_link: https://creditcards.wellsfargo.com/active-cash-credit-card
 foreign_transaction_fee: true
 network: "visa"
 our_take: >
-  The Active Cash is one of the cleanest flat-rate cards available: 2% cash
-  back on every purchase, no categories to track, and no annual fee, which is
-  why it lands at #5 on our Best Cash Back list and carries the Best No-Fee
-  badge among signup bonuses. The $200 bonus after just $500 of spending in
-  three months is one of the easiest thresholds you will find, and 12 months
-  of 0% intro APR on both purchases and balance transfers gives you a year of
-  breathing room on top. The real limitation is travel: this card charges
-  foreign transaction fees, so leave it home when you go abroad. Cell phone
-  protection worth up to $600 per claim, with a $25 deductible, when you pay
-  your phone bill with the card is a useful throw-in. If you want one card
-  that earns a solid rate on everything without any thought, this is a
-  reasonable default.
+  Active Cash is a flat 2% cash back on every purchase with no annual fee,
+  which is the simplest way to beat the 1% base rate most cards fall back to.
+  It pairs that with 12 months of 0% intro APR on both purchases and
+  qualifying balance transfers, so it can double as a short payoff window
+  before settling into a 18.49% to 28.49% regular rate. The timing is worse
+  than it was: the signup bonus was just cut from $200 to $100 after $500 of
+  spending in the first three months, so the upfront value is half what it
+  recently offered. It also charges a foreign transaction fee, which makes it
+  a poor choice abroad even though it ranks fifth on our Best Cash Back list.
+  Cell phone protection of up to $600 per claim, with a $25 deductible,
+  applies when you pay your monthly phone bill with the card.
 benefits:
   - name: "Cellular Telephone Protection"
     value: 0

--- a/data/cards/wells-fargo-attune.yaml
+++ b/data/cards/wells-fargo-attune.yaml
@@ -68,18 +68,18 @@ apr:
 apply_link: https://creditcards.wellsfargo.com/attune-credit-card
 network: "mastercard"
 our_take: >
-  Wells Fargo stopped accepting new applications for the Attune in June 2026,
-  so this is now a card you can only keep, not open. That is a genuine loss
-  for the right person, because its 4% categories were unlike anything else at
-  no annual fee: gyms and self-care, entertainment and recreation, streaming,
-  pet supplies, gardening, public transit, EV charging, and secondhand stores.
-  Everything outside that list earns just 1%, which is why the card only made
-  sense if your spending genuinely clustered in those niches, and it still
-  holds #11 on our Best Cash Back list on that strength. Existing cardholders
-  keep the earn rates plus cell phone protection of up to $600 per claim with
-  a $25 deductible. If you were hoping to apply, the Autograph is Wells
-  Fargo's remaining no-fee category card, with 3x on dining, travel, gas,
-  transit, streaming, and phone plans.
+  The Attune earned 4% back on an unusually specific set of categories,
+  covering gyms and salons, entertainment and live events, streaming, pet
+  supplies, gardening, public transit, EV charging, and secondhand stores,
+  with no annual fee. That made it a genuinely strong fit for a narrow kind of
+  spender, and it still sits at #11 on our Best Cash Back list. The decisive
+  problem is that Wells Fargo stopped accepting new applications on June 16,
+  2026, so this is now only relevant if you already hold one. If you do, the
+  card remains worth keeping for those categories, though everything outside
+  them earns just 1%, which is a real drag if your spending is broad. Anyone
+  shopping today should look at the Wells Fargo Autograph for 3x on dining,
+  travel, gas, transit, streaming, and phone plans, or Active Cash for a flat
+  2% with no categories to track.
 benefits:
   - name: "Cellular Telephone Protection"
     value: 0

--- a/data/cards/wells-fargo-autograph-journey.yaml
+++ b/data/cards/wells-fargo-autograph-journey.yaml
@@ -66,16 +66,17 @@ apply_link: https://creditcards.wellsfargo.com/autograph-journey-visa-credit-car
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Journey earns at a level that justifies its $95 annual fee if you
-  actually book travel: 5 points per dollar on hotels, 4 on airlines, and 3 on
-  dining and other travel, which is a stronger top tier than most cards at
-  this price. A $50 annual statement credit with a $50 minimum airline
-  purchase claws back more than half the fee, so the effective cost is closer
-  to $45 for anyone who buys a flight each year. The 60,000-point bonus after
-  $4,000 in three months is substantial, though that spending requirement is
-  four times what Wells Fargo's no-fee cards ask. Protection is the quiet
-  strength here: up to $1,000 per claim in cell phone coverage with a $25
-  deductible, $15,000 in trip cancellation and interruption coverage, and
-  $3,000 in lost baggage reimbursement. Everything outside travel and dining
-  earns 1x, so pair it with a flat-rate card rather than using it for general
-  spending.
+  The Autograph Journey pays 5x points on hotels and 4x on airlines, one of
+  the stronger direct-booking travel structures available for a $95 annual
+  fee, with 3x on dining and other travel and 1x on everything else. The
+  60,000 point signup bonus after $4,000 in the first three months is the
+  largest single chunk of value here, and there is no foreign transaction fee,
+  so it works overseas. Travel protections are more substantial than the fee
+  suggests: up to $15,000 in trip cancellation and interruption coverage,
+  $3,000 in lost baggage reimbursement, $1,000,000 in travel accident
+  insurance, and up to $1,000 per claim in cell phone protection with a $25
+  deductible. The $50 annual statement credit requires a $50 minimum airline
+  purchase, so treat it as a partial offset to the fee rather than a reason to
+  apply. The tradeoff is that the bonus rates are concentrated in travel and
+  dining, so if you do not book hotels and flights regularly, the 1x base rate
+  leaves most of your spending underpaid.

--- a/data/cards/wells-fargo-autograph.yaml
+++ b/data/cards/wells-fargo-autograph.yaml
@@ -55,14 +55,15 @@ apply_link: https://creditcards.wellsfargo.com/autograph-visa-credit-card
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Autograph packs an unusually wide 3x list into a card with no annual
-  fee: dining, travel, gas, transit, streaming, and phone plans all earn
-  triple points, which covers most of what a typical household spends outside
-  groceries. Add no foreign transaction fees and it works abroad as well as at
-  home, which is why it ranks #4 on our Best Travel list with the Best No-Fee
-  badge. The 20,000-point bonus after $1,000 in three months is an accessible
-  target, and 12 months of 0% intro APR on purchases gives new cardholders a
-  year to spread out a large buy. The weak spot is everything else at 1x,
-  including groceries, so most people will want a second card to cover the
-  gaps. Cell phone protection of up to $600 per claim when you pay your bill
-  with the card rounds it out.
+  The Autograph earns 3x points across an unusually wide set of everyday
+  categories: dining, travel, gas, transit, streaming, and phone plans, all
+  with no annual fee and no foreign transaction fee. That breadth is why it
+  carries the Best No-Fee badge at #7 on our Best Travel list and also places
+  on our cash back and dining rankings. A 20,000 point signup bonus after
+  $1,000 in the first three months is easy to hit, and 12 months of 0% intro
+  APR on purchases gives you room for a larger buy before the 18.49% to 28.49%
+  regular rate kicks in. The limits are the ones you would expect at this
+  price: everything outside those six categories earns 1x, and there are no
+  travel credits or lounge access to speak of. Cell phone protection of up to
+  $600 per claim when you pay your bill with the card is the one ongoing perk
+  worth noting.

--- a/data/cards/wells-fargo-cash-back-college.yaml
+++ b/data/cards/wells-fargo-cash-back-college.yaml
@@ -14,11 +14,12 @@ rewards:
     value: 1
     unit: percent
 our_take: >
-  This one is closed: Wells Fargo no longer accepts applications for the Cash
-  Back College card, so it is only relevant if you already hold it. On the
-  merits, it was a plain starter product, 1% cash back on all purchases with
-  no annual fee and no bonus categories to learn. That simplicity was the
-  point for a first card, but 1% is half of what widely available flat-rate
-  cards pay, so there is little reason to route ongoing spending here. If you
-  still have it, the sensible move is to keep it open for the credit history
-  and use something that earns more for daily purchases.
+  There is not much to weigh here anymore: the Cash Back College card is no
+  longer accepting applications, so it is only relevant to existing
+  cardholders. Even when it was open, the rewards were minimal, earning a flat
+  1% back on all purchases with no bonus categories and no signup bonus. The
+  one thing in its favor is the $0 annual fee, which means keeping it open
+  costs nothing and preserves the account age on your credit report. If you
+  are still carrying it, that is the case for leaving it open while putting
+  actual spending on a card that earns more. Students shopping today should
+  look elsewhere, because 1% flat is the floor rather than a reason to apply.

--- a/data/cards/wells-fargo-choice-privileges-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-mastercard.yaml
@@ -44,19 +44,19 @@ apply_link: https://creditcards.wellsfargo.com/choice-hotel-privileges-mastercar
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  Wells Fargo recently raised this card's signup bonus from 40,000 to 60,000
-  Choice Privileges points, and the spend to earn it is only $1,000 in the
-  first 3 months, which is one of the easier bars to clear on a no annual fee
-  card. Beyond the bonus, the everyday earn is broader than most hotel cards:
-  3 points per dollar on gas, groceries, home improvement and phone bills,
-  plus automatic Gold Elite status and 10 elite qualifying nights each year.
-  The headline 5 points per dollar applies only at participating Choice Hotels
-  properties, so it does nothing for stays outside that brand. Everything else
-  earns 1 point per dollar, and Choice points are worth relatively little per
-  point, so the value depends on actually redeeming for Choice stays. With no
-  annual fee and no foreign transaction fee, it is a low-commitment card if
-  Comfort Inn, Quality Inn and their siblings are where you sleep, and a poor
-  fit if they are not.
+  This is a no annual fee hotel card built around Choice Privileges, earning
+  5x points at participating Choice Hotels properties and 3x on gas,
+  groceries, home improvement, and phone plans, which is a wider everyday
+  footprint than most free hotel cards offer. The signup bonus was recently
+  raised from 40,000 to 60,000 points after $1,000 in the first three months,
+  so the entry value is better than it was in May. Automatic Gold Elite status
+  plus 10 elite qualifying nights each year keeps that status intact without
+  any stay requirement, and there is no foreign transaction fee. The obvious
+  limit is that the 5x rate applies only at Choice properties, so the card is
+  worth carrying mainly if Choice is a brand you actually book; everything
+  outside the bonus categories earns 1x. Cell phone protection of up to $800
+  per claim, with a $25 deductible, applies when you pay your monthly bill
+  with the card.
 benefits:
   - name: "Automatic Gold Elite Status"
     value: 0

--- a/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
+++ b/data/cards/wells-fargo-choice-privileges-select-mastercard.yaml
@@ -9,19 +9,20 @@ foreign_transaction_fee: false
 network: "mastercard"
 reward_type: "points"
 our_take: >
-  The Select's clearest case is the 30,000 point anniversary bonus: if you
-  redeem those points for Choice stays, they can outrun the $95 annual fee on
-  their own, before you count Platinum Elite status or the $120 Global Entry
-  or TSA PreCheck credit every four years. Earning is aggressive too, with 5
-  points per dollar on gas, groceries, home improvement and phone bills, and a
-  60,000 point signup bonus after $3,000 in the first 3 months. The 10 points
-  per dollar rate is limited to participating Choice Hotels properties, so
-  treat it as a stay bonus rather than a travel category, and note that
-  everything outside the bonus categories earns just 1 point per dollar. The
-  real question is whether you value Choice Privileges points enough to
-  justify a recurring fee, since the anniversary points and elite perks are
-  only useful inside that one hotel family. Cell phone protection of up to
-  $800 per claim and no foreign transaction fee round it out.
+  The Select doubles the earn rates of the free Choice Privileges card for a
+  $95 annual fee: 10x points at participating Choice Hotels properties and 5x
+  on gas, groceries, home improvement, and phone plans, with 1x on everything
+  else. The 30,000 point anniversary bonus each year is the strongest argument
+  for the fee, since it is described as roughly three reward nights at
+  participating Choice hotels and arrives whether or not you use the card
+  heavily. Add automatic Platinum Elite status with a 25% points bonus on
+  Choice stays, up to $120 for Global Entry or TSA PreCheck once every four
+  years, and no foreign transaction fee, and the fee is straightforward to
+  justify if you stay with Choice at all regularly. The signup bonus is 60,000
+  points after $3,000 in three months, the same headline number as the no-fee
+  version but at triple the spend requirement. If Choice is not a brand you
+  book, the 10x rate is dead weight and the anniversary points will not clear
+  the fee on their own.
 tags:
   - travel
   - hotel

--- a/data/cards/wells-fargo-propel-american-express.yaml
+++ b/data/cards/wells-fargo-propel-american-express.yaml
@@ -28,13 +28,13 @@ rewards:
     unit: "points_per_dollar"
 network: "amex"
 our_take: >
-  The Propel earned 3 points per dollar across an unusually wide set of
-  categories for a no annual fee card: dining, travel including flights,
-  hotels, homestays and car rentals, transit, gas and select streaming
-  services, with 1 point per dollar on everything else. That combination made
-  it a reasonable single-card setup for someone who did not want to track
-  rotating categories or pay a fee. The catch now is decisive: Wells Fargo no
-  longer accepts applications, so this is a card you can keep but not open. If
-  you already hold one, the earn structure is still competitive enough to keep
-  using for dining, gas and transit. If you do not, look at a currently
-  available card instead, because there is no way to get this one.
+  The Propel was one of the better no annual fee rewards cards of its era,
+  earning 3x points on dining, travel including flights, hotels, homestays,
+  and car rentals, transit, gas, and select streaming services, with 1x on
+  everything else. That six-way 3x structure covered most discretionary
+  spending without asking for a fee, which is why it retains a following among
+  people who still hold it. The decisive fact today is that it is closed to
+  new applications, so it is not a card you can go get. If you already have
+  one, the $0 annual fee means there is no cost to keeping it open, and the 3x
+  categories are still worth using. Anyone looking for this profile now should
+  shop the current Wells Fargo lineup rather than hoping this one reopens.

--- a/data/cards/wells-fargo-reflect.yaml
+++ b/data/cards/wells-fargo-reflect.yaml
@@ -22,15 +22,16 @@ foreign_transaction_fee: true
 network: "visa"
 our_take: >
   The Reflect is a pure balance transfer play: 21 months of 0% intro APR on
-  both purchases and qualifying balance transfers, with no annual fee, which
-  is why it sits at #3 on our Best 0% APR Credit Cards list. That runway gives
-  you close to two years to pay down existing debt or spread out a large
-  purchase before the regular 17.49% to 28.24% APR kicks in. The tradeoff is
-  that the card earns no rewards at all, so once the intro window closes there
-  is nothing to keep it in rotation. It also charges a foreign transaction
-  fee, so leave it home when you travel abroad. Cell phone protection of up to
-  $600 per claim, capped at two claims per 12 months with a $25 deductible, is
-  the only ongoing perk worth naming.
+  purchases and qualifying balance transfers, with no annual fee, which is why
+  it sits at #3 on our Best 0% APR list. That long runway makes it a solid
+  choice if your only goal is to pay down existing debt or float a big
+  purchase interest free for nearly two years. Be clear-eyed about the
+  tradeoff: this card earns no rewards at all, so there is no cash back or
+  points to keep it relevant once the intro period ends and the rate resets to
+  somewhere between 17.49% and 28.24%. It also charges a foreign transaction
+  fee, so leave it home when you travel. Cell phone protection of up to $600
+  per claim, capped at two claims per 12 months with a $25 deductible, is the
+  lone ongoing perk.
 benefits:
   - name: "Cellular Telephone Protection"
     value: 600

--- a/data/cards/wells-fargo-signify-business-cash.yaml
+++ b/data/cards/wells-fargo-signify-business-cash.yaml
@@ -6,17 +6,17 @@ apply_link: https://creditcards.wellsfargo.com/business-credit-cards/signify-bus
 foreign_transaction_fee: true
 network: "mastercard"
 our_take: >
-  The Signify's appeal is its simplicity: a flat 2% cash back on every
-  business purchase with no annual fee and no categories to track, which is
-  why it lands at #13 on our Best Cash Back Credit Cards list. The $500 bonus
-  after $5,000 in the first 3 months is strong for a card that costs nothing
-  to hold, and it carries the Best No-Fee badge at #15 on our Best Credit Card
-  Signup Bonuses list. A 12 month 0% intro APR on purchases gives new
-  businesses room to finance startup costs before the 16.74% to 24.74% regular
-  rate applies. The main gap is international spending: the card charges a
-  foreign transaction fee, so it is a poor choice for a business with overseas
-  suppliers or travel. Travel accident insurance of up to $250,000 on common
-  carrier tickets is a minor extra rather than a reason to apply.
+  The Signify Business Cash keeps it simple: a flat 2% back on every business
+  purchase with no annual fee, so there are no categories to track and no caps
+  to plan around. The $500 bonus after $5,000 of spend in the first three
+  months is within reach for most small businesses, and the 12 months of 0%
+  intro APR on purchases gives you room to finance equipment or inventory
+  early on. The tradeoff is that the flat 2% is the entire rewards program, so
+  a business with heavy shipping, advertising, or travel spend will out-earn
+  it elsewhere. It also charges foreign transaction fees, which makes it a
+  poor fit if you buy from overseas suppliers or travel internationally. Up to
+  $250,000 in travel accident insurance when you buy tickets with the card is
+  a minor extra, not a reason to apply.
 image: "wells-fargo-signify-business-cash.png"
 category: "business"
 annual_fee: 0

--- a/data/cards/world-of-hyatt-business-credit-card.yaml
+++ b/data/cards/world-of-hyatt-business-credit-card.yaml
@@ -79,17 +79,17 @@ apply_link: https://creditcards.chase.com/business-credit-cards/world-of-hyatt/h
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  This card's most distinctive feature is the 2 points per dollar that lands
-  automatically in your top three spend categories each quarter, drawn from
-  dining, shipping, airline tickets bought directly, transit, advertising, car
-  rentals, gas and internet, cable and phone, so you never have to nominate
-  anything. Chase moved the signup bonus around this year, cutting it from
-  80,000 to 60,000 points in April before raising it to 70,000 after $7,000 in
-  the first 3 months, which is a reasonable entry point for a $199 annual fee.
-  Hyatt loyalists get the most here: Discoverist status, up to $100 in Hyatt
-  statement credits per anniversary year, 5 tier-qualifying night credits for
-  every $10,000 spent, and 4 points per dollar that only applies at Hyatt
-  properties. The fee is real money, though, and the 10% points back perk
-  requires $50,000 of annual spend, so it stays out of reach for smaller
-  businesses. If your team does not book Hyatt regularly, a flat-rate business
-  card will serve you better despite the strong bonus.
+  Chase recently raised the welcome offer from 60,000 to 70,000 points after
+  $7,000 of spend in three months, which is the clearest reason to open this
+  card right now. Ongoing, it works as an elite-status shortcut: automatic
+  Discoverist status, 5 tier-qualifying night credits for every $10,000 you
+  spend in a calendar year, and up to $100 in Hyatt statement credits per
+  anniversary year, paid as two separate $50 credits. The 2x rate is unusually
+  flexible, applying automatically to your top three spend categories each
+  quarter from a list that includes dining, shipping, airfare bought directly
+  from the airline, transit, car rentals, gas, advertising, and internet and
+  phone service, with another 2x on gym memberships. Be clear that the 4x
+  hotel rate counts only at Hyatt properties and everything outside the bonus
+  lists earns a plain 1x, so the $199 annual fee needs real Hyatt stays or
+  genuine status ambitions behind it. If you rarely sleep at a Hyatt, the
+  credits alone will not cover the fee.

--- a/data/cards/world-of-hyatt-credit-card.yaml
+++ b/data/cards/world-of-hyatt-credit-card.yaml
@@ -76,17 +76,15 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/world-of-hyatt-cre
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The annual Category 1-4 free night award is the whole argument for this
-  card: one night at a qualifying Hyatt property can easily cover the $95
-  annual fee, and you can earn a second by spending $15,000 in a cardmember
-  year. Chase has raised the welcome offer twice recently, from 30,000 points
-  in June to 75,000 now, structured as 45,000 points after $5,000 in the first
-  3 months plus up to 30,000 more at 2 bonus points per dollar on $15,000 in
-  the first 6 months, so the full amount takes real spending over half a year.
-  Day to day you get 2 points per dollar on dining, transit, gym memberships
-  and airfare booked directly with the airline, with 1 point per dollar on
-  everything else; the 4 points per dollar rate applies only at Hyatt hotels.
-  Discoverist status and 5 qualifying night credits each year help if you are
-  chasing Hyatt elite tiers. It is a narrow card by design: worth holding if
-  you stay at Hyatt even a couple of times a year, and not much use if you do
-  not.
+  The annual Category 1 to 4 free night award is the whole case for this card,
+  and a single well-placed redemption can cover the $95 annual fee on its own.
+  You also get automatic Discoverist status, 5 qualifying night credits toward
+  higher tiers each year, and a second Category 1 to 4 free night if you spend
+  $15,000 in a cardmember year. The signup bonus was recently trimmed back to
+  60,000 points from 75,000, and its structure is slow: 30,000 points after
+  $3,000 in the first three months, then up to 30,000 more earned as an extra
+  point per dollar on up to $15,000 of spending across six months. Earn rates
+  outside the chain are modest, at 2x on dining, airfare booked directly with
+  airlines, transit, and gym memberships, and 1x on everything else, while the
+  4x hotel rate applies only at Hyatt properties. Hold it for the free night
+  and the status, not as the card you reach for on everyday spending.

--- a/data/cards/wyndham-rewards-earner-business-card.yaml
+++ b/data/cards/wyndham-rewards-earner-business-card.yaml
@@ -4,19 +4,17 @@ slug: "wyndham-rewards-earner-business-card"
 accepting_applications: true
 apply_link: https://cards.barclaycardus.com/banking/cards/wyndham-rewards-earner-business-card/
 our_take: >
-  The draw here is 5 points per dollar on a genuinely useful spread of
-  business spending: gas, EV charging, office supplies, and shipping, with no
-  foreign transaction fee and automatic Wyndham Rewards Diamond status on top.
-  Barclays raised the annual fee from $95 to $149 in June 2026 and at the same
-  time doubled the welcome offer to 100,000 points, split across 45,000 points
-  after $3,000 in the first 90 days and 55,000 more after $500 at Hotels by
-  Wyndham within 180 days. The headline 8 points per dollar applies only at
-  Wyndham properties, so treat it as a loyalty rate rather than a general
-  hotel rate, and note that everything outside the bonus categories earns just
-  1 point per dollar. Ongoing value leans on 15,000 anniversary points, a 20%
-  discount when redeeming for free nights, and up to $65 a year toward a
-  warehouse club membership. It makes sense if your business spends regularly
-  at Wyndham and in those 5x categories; if it does not, the higher fee is
+  Barclays raised the annual fee from $95 to $149 in June, but it lifted the
+  welcome offer from 45,000 to 100,000 points at the same time: 45,000 after
+  $3,000 of spend in 90 days, plus 55,000 more after $500 at Hotels by Wyndham
+  within 180 days. The ongoing earn is unusually broad for a hotel card, with
+  5x on gas, EV charging, office supplies, and shipping, which fits a business
+  that drives and ships more than it flies. The recurring value is real too:
+  15,000 anniversary points each year, enough for up to two free award nights,
+  plus automatic Diamond status, 20% fewer points on award bookings, and up to
+  $65 a year toward a warehouse club membership. The limits are that the 8x
+  rate applies only at Wyndham properties and everything outside the bonus
+  list drops to 1x. If your travel does not run through Wyndham, the $149 is
   hard to earn back.
 category: "business"
 image: "barclays-wyndham-earner-business.png"

--- a/data/cards/wyndham-rewards-earner-card.yaml
+++ b/data/cards/wyndham-rewards-earner-card.yaml
@@ -9,19 +9,18 @@ annual_fee: 0
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  This is the no annual fee entry point to Wyndham Rewards, and the pitch is
-  simple: 5 points per dollar at Hotels by Wyndham, plus 3 points per dollar
-  on dining and groceries, with no foreign transaction fee. The welcome offer
-  is 75,000 points, structured as 30,000 after $1,000 in purchases in the
-  first 90 days and 45,000 more after $500 at Hotels by Wyndham within 180
-  days, so you need an actual Wyndham stay to collect all of it. There is also
-  a 15 month 0% intro APR on balance transfers, which is a reasonable side
-  benefit but not the reason to apply. The tradeoffs are that the 5x rate is
-  limited to Wyndham properties, the grocery category excludes Target and
-  Walmart, everything else earns a flat 1 point per dollar, and the
-  anniversary bonus of 7,500 points requires $15,000 of spending to trigger.
-  Automatic Gold status and a 10% discount on award redemptions round it out:
-  modest, but at $0 a year there is little to lose.
+  For a card with no annual fee, the Earner asks very little up front: 75,000
+  points total, split as 30,000 after $1,000 of spend in 90 days and 45,000
+  more after just $500 at Hotels by Wyndham within 180 days. Day to day it
+  earns 5x at Wyndham properties, 3x on dining and groceries excluding Target
+  and Walmart, and 1x on everything else, alongside automatic Gold status and
+  a 10% discount when you redeem points for free nights. There is also 15
+  months of 0% intro APR on balance transfers, a useful side door on a card
+  that costs nothing to keep. The catches are modest but real: the 7,500-point
+  anniversary bonus only triggers after $15,000 of spend, and the headline 5x
+  rate counts only at Wyndham hotels. If Wyndham is not in your travel
+  rotation, the 3x dining and grocery rates are not enough to carry the card
+  on their own.
 reward_type: "points"
 tags:
   - hotel

--- a/data/cards/wyndham-rewards-earner-plus-card.yaml
+++ b/data/cards/wyndham-rewards-earner-plus-card.yaml
@@ -46,20 +46,19 @@ apr:
     min: 19.24
     max: 29.99
 our_take: >
-  The Plus is the middle option, and it earns its keep on the anniversary
-  bonus: 15,000 points every year, which Wyndham says covers up to two free
-  award nights, against a $95 annual fee that Barclays raised from $75 in June
-  2026. Earning is a step up from the no fee version, with 6 points per dollar
-  at Hotels by Wyndham, 4 points per dollar on dining, groceries, and travel,
-  and no foreign transaction fee. The welcome offer is 100,000 points, split
-  between 45,000 after $1,000 in purchases in the first 90 days and 55,000
-  more after $500 at Hotels by Wyndham within 180 days. Be clear on the
-  limits: the 6x rate applies only at Wyndham properties, all other spending
-  earns 1 point per dollar, and the free night worth up to 15,000 points
-  requires five or more paid nights in a calendar year. Status settles at
-  Platinum after a first year of Diamond, and the redemption discount is 10%,
-  so this really only pencils out if you stay with Wyndham more than once a
-  year.
+  The Plus is the middle card in the Wyndham lineup and the easiest to justify
+  if you stay with the chain a few times a year: 15,000 anniversary points,
+  enough for up to two free award nights, already outrun the $95 annual fee
+  that Barclays raised from $75 in June. The welcome offer is generous
+  relative to the spend required, at 100,000 points total, 45,000 after $1,000
+  in the first 90 days and 55,000 more after $500 at Hotels by Wyndham within
+  180 days. Earning runs 6x at Wyndham properties and a solid 4x on dining,
+  groceries, and travel, with 15 months of 0% intro APR on balance transfers
+  if you need it. Status is Diamond in the first year and Platinum after that,
+  and you get a free night worth up to 15,000 points once you stay five nights
+  in a calendar year. The weak spot is the 1x rate on everything outside those
+  categories, and the fact that 6x applies only at Wyndham, so this rewards
+  loyalty rather than general spending.
 benefits:
   - name: "Anniversary Points Bonus"
     value: 15000

--- a/data/cards/wyndham-rewards-earner-premier-card.yaml
+++ b/data/cards/wyndham-rewards-earner-premier-card.yaml
@@ -36,24 +36,22 @@ rewards:
     unit: points_per_dollar
     note: "Also earns 4x on Wyndham Vacation Club purchases"
 our_take: >
-  At $395 a year, the Premier is built around a stack of recurring credits and
-  points rather than raw earn rates: 30,000 anniversary points after you pay
-  the fee, a free night worth up to 30,000 points once you stay five or more
-  nights in a calendar year, a 25% discount on award redemptions, and up to
-  $100 in Wyndham hotel credits, $120 in meal delivery credits at $10 a month,
-  $100 in streaming credits, and $65 toward a wholesale club membership.
-  Earning is 8 points per dollar at Hotels by Wyndham, which applies only at
-  Wyndham properties, plus 4 points per dollar on travel, dining, and
-  groceries, with Target and Walmart excluded and everything else at 1 point
-  per dollar. The current limited time welcome offer is 120,000 points, but it
-  is the most demanding of the family: 90,000 after $6,000 in spending and
-  paying the annual fee in full, both within 120 days, then 30,000 more after
-  $750 at Hotels by Wyndham within 180 days. Diamond status, a $95 Wyndham
-  Rewards Insider subscription, up to $120 toward Global Entry or TSA PreCheck
-  every four years, and no foreign transaction fee fill out the package. The
-  math only works if you actually use the monthly credits and stay at Wyndham
-  enough to clear five nights; otherwise the cheaper Plus covers most of the
-  same ground for $300 less.
+  The Premier costs $395, and its credits are stacked so a Wyndham regular can
+  clear that on paper: 30,000 anniversary points, a free night worth up to
+  30,000 points after five nights in a calendar year, up to $100 back at
+  Wyndham hotels, $120 a year for meal delivery, $100 a year on streaming, and
+  $65 toward a wholesale club membership. The current limited-time offer is
+  120,000 points, with 90,000 after $6,000 of spend and paying the annual fee
+  in full within 120 days, plus 30,000 more after $750 at Hotels by Wyndham in
+  the first 180 days. Ongoing you get 8x at Wyndham properties, 4x on travel,
+  dining, and groceries excluding Target and Walmart, automatic Diamond
+  status, and a 25% discount on award redemptions that quietly stretches every
+  point you hold. The honest catch is that much of the value is credit value:
+  the meal delivery credit doles out $10 a month, the streaming and wholesale
+  club credits only pay if you use those services, and everything outside the
+  bonus categories earns 1x. Unless you spend several nights a year at Wyndham
+  and will actually work through the monthly credits, the fee outruns what
+  comes back.
 signup_bonus:
   value: 120000
   type: "points"


### PR DESCRIPTION
Twice-monthly regeneration of the `our_take` editorial paragraph, written in-session by the local `our-takes-refresh-local` routine rather than by a gpt-4o call per card.

**208 card(s) changed.** Cards whose copy came out byte-identical are not touched, so everything in this diff is a real rewrite.

House style is pinned in the prompt: one paragraph, no em dashes, lead with the strongest reason to carry the card, name the catch honestly, no clickbait.

Skim for accuracy against each card. Merging fires Build and Deploy Cards on the `data/cards/**` push trigger, which refreshes cards.json on the CDN.
