### PR TITLE
Reddit Data Points 2026-09-02

### DIFF
--- a/data/reddit-datapoints/2026-09-02-t3_1w4z5uu.yaml
+++ b/data/reddit-datapoints/2026-09-02-t3_1w4z5uu.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1w4z5uu"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1w4z5uu/travel_card_request_not_coupon_book/"
+posted: "2026-09-02"
+evidence: "In a card-recommendation profile the poster reports applying for the BofA Atmos Summit last month on the 100k offer and being denied, listing an Equifax FICO of 743, $200k income, and four open cards."
+card_name: "Atmos Rewards Summit"
+result: "denied"
+credit_score: 743
+credit_score_source: 3
+listed_income: 200000
+length_credit: 2
+total_open_cards: 4
+date_applied: "2026-08"
+reason_denied_code: "not_specified"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-09-02

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1w4z5uu](https://www.reddit.com/r/CreditCards/comments/1w4z5uu/travel_card_request_not_coupon_book/) | Atmos Rewards Summit | denied | 743 | $200,000 | — | 2 | 2026-08 | `2026-09-02-t3_1w4z5uu.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (6)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [Trying to get Savor to pair with Venture X to complete setup](https://www.reddit.com/r/CreditCards/comments/1vync0s/trying_to_get_savor_to_pair_with_venture_x_to/) | Capital One Venture X Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [Back to back approvals for Altitude Go + MCP](https://www.reddit.com/r/CreditCards/comments/1w068db/back_to_back_approvals_for_altitude_go_mcp/) | US Bank Altitude Go Visa Signature · approved | credit_score | What was your score at the time, and which bureau? |
| [Got my first credit card at 26 after being scared to get one](https://www.reddit.com/r/CreditCards/comments/1w2ri7t/got_my_first_credit_card_at_26_after_being_scared/) | Capital One Quicksilver Secured Cash Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [AMEX Blue Cash Preferred 3x Credit Line Increase Strategy?](https://www.reddit.com/r/CreditCards/comments/1w1xm9d/amex_blue_cash_preferred_3x_credit_line_increase/) | Blue Cash Preferred · approved | credit_score | What was your score at the time, and which bureau? |
| [I got approved for a Chase Freedom Unlimited, now what?](https://www.reddit.com/r/CreditCards/comments/1w3zjrz/i_got_approved_for_a_chase_freedom_unlimited_now/) | Chase Freedom Unlimited · approved | credit_score | What was your score at the time, and which bureau? |
| [Applying for two credit cards back to back](https://www.reddit.com/r/CreditCards/comments/1w5bg9u/applying_for_two_credit_cards_back_to_back/) | Blue Cash Preferred · approved | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_outcome` | 6 | No stated approval or denial (odds question, recommendation request, chatter) |
| `duplicate` | 1 | Same application already recorded |
| `pre_qual` | 1 | Pre-qualification or pre-approval result, which is never an outcome |


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
