### PR TITLE
fix(social): stop LLM breaking every sentence onto its own line

### DIFF
--- a/scripts/lib/social-text.js
+++ b/scripts/lib/social-text.js
@@ -74,8 +74,10 @@ function enforceTweetLimit(input, limit = TWEET_TEXT_LIMIT) {
     clipped.lastIndexOf('. '),
     clipped.lastIndexOf('.')
   );
-  // Only accept a clean break if it keeps most of the post.
-  if (lastBreak >= limit * 0.6) {
+  // Prefer ending on a complete sentence or line. Accept the break as long as
+  // it keeps at least half the post; ending a fact short reads better than the
+  // ellipsis fallback, which can clip mid-number.
+  if (lastBreak >= limit * 0.5) {
     return clipped.slice(0, lastBreak + 1).trim().replace(/[\s,;:]+$/g, '');
   }
   return `${clipped.slice(0, limit - 3).trim()}...`;

--- a/scripts/lib/social-text.test.js
+++ b/scripts/lib/social-text.test.js
@@ -107,6 +107,16 @@ test('overlong text is cut at a sentence boundary, not mid-number', () => {
   assert.ok(!out.endsWith('...'), 'fell back to ellipsis despite clean breaks');
 });
 
+// A single long lead sentence followed by an overrunning second one: the only
+// sentence boundary sits just past halfway, so the clean-break path has to
+// accept it rather than clipping the second sentence mid-word.
+test('a lone early sentence boundary is preferred over an ellipsis', () => {
+  const lead = `NEW: ${'x'.repeat(130)}.`;
+  const out = enforceTweetLimit(`${lead} ${'y'.repeat(200)} trailing words`);
+  assert.equal(out, lead, `did not cut back to the lead sentence: ${out}`);
+  assert.ok(!out.endsWith('...'), 'fell back to ellipsis despite a clean break');
+});
+
 test('text with no clean break falls back to an ellipsis within the limit', () => {
   const out = enforceTweetLimit('a'.repeat(300), 50);
   assert.equal(out.length, 50);

--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -93,10 +93,13 @@ Voice: a factual trade-desk account. Informative and specific, never promotional
 and never meme-y. The reader should finish the post knowing the concrete facts.
 
 Rules:
-- Max ${TWEET_TEXT_LIMIT} characters total. Length is fine when every line carries a fact;
-  do not pad to fill it, and do not compress facts out to be short
-- Multiple lines are encouraged. Put each distinct fact (dates, cities, prices,
-  deadlines) on its own line so the post scans
+- Hard limit ${TWEET_TEXT_LIMIT} characters. Aim for 200 to 230: anything over the limit is
+  cut off mid-sentence, so finish the thought inside the budget. Do not pad to
+  fill it, and do not compress facts out to be short
+- Default to a single paragraph of plain sentences. Line breaks are for lists,
+  not for prose: use them only when there are three or more parallel items
+  (cities, tiers, dated milestones), and then put one item per line. Two
+  sentences that continue one thought stay on the same line
 - Lead with "NEW:" or "BREAKING:" when the item is genuinely new, otherwise open
   with the plain factual statement
 - State the concrete terms from the summary (exact amounts, spend requirements,
@@ -107,7 +110,7 @@ Rules:
 - 1 hashtag max, only if it adds value. Skip hashtags if the tweet is strong without one
 - Do NOT include any URL
 - Do NOT use emojis, emoticons, or decorative symbols anywhere. Zero emoji
-- Do NOT use em dashes or en dashes. Use a period, comma, colon, or new line instead`;
+- Do NOT use em dashes or en dashes. Use a period, comma, or colon instead`;
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',

--- a/scripts/queue-social.js
+++ b/scripts/queue-social.js
@@ -146,10 +146,13 @@ Voice: a factual trade-desk account. Informative and specific, never promotional
 and never meme-y. The reader should finish the post knowing the concrete facts.
 
 Rules:
-- Max ${TWEET_TEXT_LIMIT} characters total. Length is fine when every line carries a fact;
-  do not pad to fill it, and do not compress facts out to be short
-- Multiple lines are encouraged. Put each distinct fact (dates, cities, prices,
-  deadlines) on its own line so the post scans
+- Hard limit ${TWEET_TEXT_LIMIT} characters. Aim for 200 to 230: anything over the limit is
+  cut off mid-sentence, so finish the thought inside the budget. Do not pad to
+  fill it, and do not compress facts out to be short
+- Default to a single paragraph of plain sentences. Line breaks are for lists,
+  not for prose: use them only when there are three or more parallel items
+  (cities, tiers, dated milestones), and then put one item per line. Two
+  sentences that continue one thought stay on the same line
 - Lead with "NEW:" or "BREAKING:" when the item is genuinely new, otherwise open
   with the plain factual statement
 - State the concrete terms from the summary (exact amounts, spend requirements,
@@ -170,7 +173,7 @@ Rules:
 - 1 hashtag max, only if it adds value. Skip hashtags if the tweet is strong without one
 - Do NOT include any URL
 - Do NOT use emojis, emoticons, or decorative symbols anywhere. Zero emoji
-- Do NOT use em dashes or en dashes. Use a period, comma, colon, or new line instead`;
+- Do NOT use em dashes or en dashes. Use a period, comma, or colon instead`;
 
   const response = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
     method: 'POST',


### PR DESCRIPTION
## Problem

Generated tweets were coming out with a hard line break after every sentence. On X a single `\n` renders tight with no paragraph gap, so the post reads as an unmarked list, and when a line is long enough to soft-wrap you get a wrapped block, a hard break, then another wrapped block, with the break landing mid-thought.

Example from the IHG post published 2026-09-02:

```
NEW: IHG One Rewards Premier Business cardholders are notified that anniversary
free nights starting in 2027 will have a cap of 50,000 points, up from 40,000.
Certificates issued through December 31, 2026 will retain the 40,000 point limit.
```

## Cause

Two rules in the generation prompt, duplicated in `queue-social.js` and `post-social.js`:

- `Put each distinct fact (dates, cities, prices, deadlines) on its own line so the post scans` — gpt-4o-mini applies this per **sentence**, not per fact, so every period became a line break.
- `Do NOT use em dashes... Use a period, comma, colon, or new line instead` — offered a newline as punctuation, reinforcing it.

`sanitizeSocialText` only collapses runs of 3+ newlines, so single breaks passed through untouched.

## Fix

- Line breaks are now reserved for genuinely enumerable content (three or more parallel items such as cities, tiers, dated milestones). Prose stays in one paragraph.
- Dropped "or new line" from the em-dash substitutes.

The rule was written for posts like a lounge announcement with four cities, where one-fact-per-line does help scanning. That case still works; it just no longer fires on two prose sentences.

## Follow-on

Prose runs longer than the old line-per-fact style, and the first pass started overrunning the 255-char cap and truncating mid-word (`...offers $100 back after $50...`). Two changes:

- The length rule now states a 200-230 target with the hard cap called out explicitly.
- `enforceTweetLimit` accepts a sentence boundary at half the limit instead of `0.6`, so an overrun ends on a complete sentence rather than the ellipsis fallback. Covered by a new test.

## Verification

`node scripts/lib/social-text.test.js` passes (6 tests, 1 new).

Dry-ran 8 real news items through `queue-social.js --dry-run`. All came back as single paragraphs with no stray breaks and no truncation. Sample:

```
NEW: Southwest is building its first airport lounges in Austin, Baltimore,
Honolulu, and Nashville, with expected guest access in late 2027. Access will be
available through a new premium Southwest Rapid Rewards card from Chase,
launching in 2027.
```

Affects future posts only; nothing already queued or published changes.