### PR TITLE
fix(social): stop generated posts dropping a summary's attribution

### DIFF
--- a/scripts/lib/social-text.js
+++ b/scripts/lib/social-text.js
@@ -83,4 +83,154 @@ function enforceTweetLimit(input, limit = TWEET_TEXT_LIMIT) {
   return `${clipped.slice(0, limit - 3).trim()}...`;
 }
 
-module.exports = { TWEET_TEXT_LIMIT, TWEET_MAX, sanitizeSocialText, enforceTweetLimit };
+/**
+ * Outlets and sources that are NOT the company the story is about. When a
+ * summary hangs a claim on one of these, the claim is somebody's reporting
+ * rather than an issuer announcement, and the post has to say so.
+ *
+ * A first-party attribution ("Southwest said on September 2", "Citi is
+ * mailing") is deliberately not in this list: the issuer speaking about its
+ * own product is the confirmation, so a post may state it flatly.
+ */
+const THIRD_PARTY_SOURCES = [
+  'doctor of credit',
+  'the points guy',
+  'nerdwallet',
+  'upgraded points',
+  'thrifty traveler',
+  'view from the wing',
+  'one mile at a time',
+  'frequent miler',
+  'wall street journal',
+  'bloomberg',
+  'reuters',
+  'reddit',
+  'r/churning',
+  'r/creditcards',
+  'cardholders report',
+  'cardholder reports',
+  'data points',
+];
+
+/**
+ * Words that mark a claim as unverified regardless of who said it.
+ */
+const UNCERTAINTY_MARKERS = [
+  'unconfirmed',
+  'rumor',
+  'rumored',
+  'rumours',
+  'reportedly',
+  'allegedly',
+  'appears to',
+  'appear to',
+  'is said to',
+  'are said to',
+  'has not confirmed',
+  'have not confirmed',
+  'not confirmed',
+  'has not published',
+  'not yet confirmed',
+  'no official',
+];
+
+function containsAny(haystack, needles) {
+  const lower = haystack.toLowerCase();
+  return needles.filter((needle) => lower.includes(needle));
+}
+
+const CLAIM_STOPWORDS = new Set([
+  'the', 'and', 'that', 'this', 'with', 'from', 'for', 'its', 'it', 'is', 'are',
+  'was', 'were', 'has', 'have', 'had', 'will', 'would', 'can', 'could', 'been',
+  'not', 'but', 'they', 'their', 'them', 'there', 'then', 'than', 'also', 'only',
+  'now', 'new', 'per', 'each', 'all', 'any', 'some', 'more', 'most', 'other',
+  'into', 'out', 'over', 'under', 'after', 'before', 'when', 'which', 'who',
+  'what', 'how', 'says', 'said', 'reports', 'reported', 'according', 'card',
+  'cards', 'cardholders', 'cardholder', 'takes', 'take', 'place', 'current',
+]);
+
+/**
+ * The distinctive content of a claim: numbers and dollar amounts, plus words
+ * long enough to carry meaning. Used to tell "the post repeated this claim"
+ * from "the post left this claim out".
+ */
+function claimTokens(sentence) {
+  const lower = String(sentence || '').toLowerCase();
+  const tokens = new Set();
+  for (const amount of lower.match(/\$[\d,.]+|\b\d[\d,.]*\b/g) || []) {
+    tokens.add(amount.replace(/[.,]$/, ''));
+  }
+  for (const word of lower.match(/[a-z][a-z-]{2,}/g) || []) {
+    if (!CLAIM_STOPWORDS.has(word)) tokens.add(word);
+  }
+  return tokens;
+}
+
+/**
+ * The sentences of `summary` that carry one of `markers`.
+ */
+function markedSentences(summary, markers) {
+  return String(summary || '')
+    .split(/(?<=[.!?])\s+/)
+    .filter((sentence) => containsAny(sentence, markers).length > 0);
+}
+
+/**
+ * True when `text` repeats the substance of `sentence` rather than omitting it.
+ * Two distinctive tokens in common is enough: a dollar amount plus a noun is
+ * the shape of nearly every claim we publish.
+ */
+function restatesClaim(sentence, text) {
+  const claim = claimTokens(sentence);
+  if (claim.size === 0) return false;
+  const post = claimTokens(text);
+  let shared = 0;
+  for (const token of claim) {
+    if (post.has(token)) shared++;
+    if (shared >= 2) return true;
+  }
+  return false;
+}
+
+/**
+ * Detect the failure where a summary carefully attributes or hedges a claim
+ * ("Doctor of Credit reports it takes the place of the $5 promo") and the
+ * generated post restates it as established fact ("This replaces the $5
+ * promo"). The hedge is the whole point of the sentence, so dropping it
+ * publishes a stronger claim than the reporting supports.
+ *
+ * Fires only when the post BOTH repeats the substance of the hedged claim AND
+ * carries no attribution or hedge of its own. A post that leaves the claim out
+ * entirely is fine, and so is a confirmed story with no hedge to begin with.
+ *
+ * Returns null when the post is fine, or { marker, kind } describing the hedge
+ * that went missing.
+ */
+function findFlattenedAttribution(summary, text) {
+  const summaryText = String(summary || '');
+  const postText = String(text || '');
+  if (!summaryText || !postText) return null;
+
+  const checks = [
+    { kind: 'uncertainty', markers: UNCERTAINTY_MARKERS },
+    { kind: 'attribution', markers: THIRD_PARTY_SOURCES },
+  ];
+
+  for (const { kind, markers } of checks) {
+    const found = containsAny(summaryText, markers);
+    if (found.length === 0) continue;
+
+    // The post carries a hedge of its own, or names the same source.
+    if (containsAny(postText, UNCERTAINTY_MARKERS).length > 0) return null;
+    if (containsAny(postText, found).length > 0) return null;
+
+    const restated = markedSentences(summaryText, found)
+      .some((sentence) => restatesClaim(sentence, postText));
+    if (restated) return { marker: found[0], kind };
+  }
+
+  return null;
+}
+
+module.exports = { TWEET_TEXT_LIMIT, TWEET_MAX, sanitizeSocialText, enforceTweetLimit,
+  findFlattenedAttribution, THIRD_PARTY_SOURCES, UNCERTAINTY_MARKERS };

--- a/scripts/lib/social-text.test.js
+++ b/scripts/lib/social-text.test.js
@@ -23,6 +23,7 @@ const {
   TWEET_MAX,
   sanitizeSocialText,
   enforceTweetLimit,
+  findFlattenedAttribution,
 } = require('./social-text.js');
 
 let failures = 0;
@@ -127,6 +128,77 @@ test('text already within the limit is returned unchanged apart from sanitizing'
   const clean = 'NEW: Citi expands Curated Table for Strata Elite cardmembers.';
   assert.equal(enforceTweetLimit(clean), clean);
 });
+
+console.log('\nattribution and hedging');
+
+// A summary that hangs a claim on an outlet must not become a bare assertion.
+// This is the 2026-09-02 Sapphire Reserve DoorDash post, which published
+// "This replaces the current $5 credit" from a summary that said Doctor of
+// Credit reported it.
+test('an outlet attribution dropped from the post is caught', () => {
+  const summary = 'Doctor of Credit reports it takes the place of the current $5 restaurant only promo.';
+  const hit = findFlattenedAttribution(summary, 'This replaces the current $5 restaurant-only promo.');
+  assert.ok(hit, 'flattened attribution went undetected');
+  assert.equal(hit.kind, 'attribution');
+  assert.equal(hit.marker, 'doctor of credit');
+});
+
+test('a post that keeps the outlet attribution passes', () => {
+  const summary = 'Doctor of Credit reports it takes the place of the current $5 promo.';
+  assert.equal(findFlattenedAttribution(summary, 'Doctor of Credit reports it replaces the $5 promo.'), null);
+});
+
+test('an uncertainty marker dropped from the post is caught', () => {
+  const summary = 'Unconfirmed: a cardholder says Chase will drop the foreign transaction fee.';
+  const hit = findFlattenedAttribution(summary, 'Chase will drop the foreign transaction fee.');
+  assert.ok(hit);
+  assert.equal(hit.kind, 'uncertainty');
+});
+
+test('a hedge kept in different words still passes', () => {
+  const summary = 'Unconfirmed: a cardholder says Chase will drop the fee.';
+  assert.equal(findFlattenedAttribution(summary, 'Chase reportedly will drop the fee.'), null);
+});
+
+// The issuer speaking about its own product is the confirmation, so a post may
+// state it flatly. These are the common case and must never block a queue.
+test('a first-party issuer statement is not treated as a hedge', () => {
+  const summary = 'Southwest said on September 2, 2026 that it is building its first airport lounges.';
+  assert.equal(findFlattenedAttribution(summary, 'Southwest is building its first airport lounges.'), null);
+});
+
+test('a summary with no hedge at all passes', () => {
+  const summary = 'Citi is mailing Sunoco cardholders notice that every account closes on October 31, 2026.';
+  assert.equal(findFlattenedAttribution(summary, 'Citi is closing every Sunoco account on October 31, 2026.'), null);
+});
+
+// The prompt lets the model drop a hedged claim instead of hedging it. A post
+// that leaves the claim out is correct and must not be blocked, even though the
+// summary still names the outlet.
+test('a post that omits the hedged claim entirely passes', () => {
+  const summary = 'Starting October 1, 2026, Chase Sapphire Reserve cardholders get a $15 monthly '
+    + 'DoorDash credit that works on any eligible order. Doctor of Credit reports it takes the '
+    + 'place of the current $5 restaurant only promo.';
+  const post = 'Starting October 1, 2026, Chase Sapphire Reserve cardholders will receive a $15 '
+    + 'monthly DoorDash credit applicable to any eligible order, including restaurants.';
+  assert.equal(findFlattenedAttribution(summary, post), null);
+});
+
+test('restating the hedged claim without the hedge is still caught', () => {
+  const summary = 'Starting October 1, 2026, cardholders get a $15 monthly DoorDash credit. '
+    + 'Doctor of Credit reports it takes the place of the current $5 restaurant only promo.';
+  const post = 'Cardholders get a $15 monthly DoorDash credit. This replaces the current $5 '
+    + 'restaurant-only promo.';
+  const hit = findFlattenedAttribution(summary, post);
+  assert.ok(hit, 'flattened claim went undetected');
+  assert.equal(hit.kind, 'attribution');
+});
+
+test('empty input is safe', () => {
+  assert.equal(findFlattenedAttribution('', 'anything'), null);
+  assert.equal(findFlattenedAttribution('Doctor of Credit reports a change.', ''), null);
+});
+
 
 console.log(failures === 0 ? '\nAll tests passed.' : `\n${failures} test(s) failed.`);
 process.exit(failures === 0 ? 0 : 1);

--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -104,6 +104,13 @@ Rules:
   with the plain factual statement
 - State the concrete terms from the summary (exact amounts, spend requirements,
   dates, deadlines). "$200 back on $1,000" beats "a great new offer"
+- Preserve the summary's certainty. When the summary attributes a claim to an
+  outlet ("Doctor of Credit reports", "according to the Wall Street Journal") or
+  marks it unverified ("unconfirmed", "rumored", "cardholders report"), keep that
+  attribution or hedge on the same claim in the post. Never restate a reported or
+  rumored claim as established fact. If it will not fit, drop the claim instead of
+  the hedge. A company speaking about its own product ("Chase said", "Citi is
+  mailing") is confirmation, so that may be stated flatly
 - Plain declarative sentences. No hype, no rhetorical questions, no second-person
   hard sell, no "don't miss", no "act fast", no exclamation marks
 - No filler words, no "excited to announce", no "stay tuned"

--- a/scripts/queue-social.js
+++ b/scripts/queue-social.js
@@ -16,7 +16,7 @@
 const fs = require('fs');
 const yaml = require('js-yaml');
 const { appendBankHandles, resolveBanksFromCardNames } = require('./lib/bank-handles');
-const { TWEET_TEXT_LIMIT, enforceTweetLimit } = require('./lib/social-text');
+const { TWEET_TEXT_LIMIT, enforceTweetLimit, findFlattenedAttribution } = require('./lib/social-text');
 
 async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -119,7 +119,7 @@ function getCardNameList(item) {
   return [];
 }
 
-async function generatePost(type, item) {
+async function generatePost(type, item, corrective = '') {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) throw new Error('OPENAI_API_KEY is required');
 
@@ -159,6 +159,13 @@ Rules:
   dates, deadlines). "$200 back on $1,000" beats "a great new offer"
 - Every fact must come from the summary. Do not add, infer, or extrapolate a
   detail the summary does not state, even an obvious-sounding one
+- Preserve the summary's certainty. When the summary attributes a claim to an
+  outlet ("Doctor of Credit reports", "according to the Wall Street Journal") or
+  marks it unverified ("unconfirmed", "rumored", "cardholders report"), keep that
+  attribution or hedge on the same claim in the post. Never restate a reported or
+  rumored claim as established fact. If it will not fit, drop the claim instead of
+  the hedge. A company speaking about its own product ("Chase said", "Citi is
+  mailing") is confirmation, so that may be stated flatly
 - Timing phrases ("in the coming weeks", "starting September 1", "effective
   immediately") belong to exactly one event. Keep each one attached to the same
   event the summary attaches it to, and never move it onto a different one. If
@@ -173,7 +180,7 @@ Rules:
 - 1 hashtag max, only if it adds value. Skip hashtags if the tweet is strong without one
 - Do NOT include any URL
 - Do NOT use emojis, emoticons, or decorative symbols anywhere. Zero emoji
-- Do NOT use em dashes or en dashes. Use a period, comma, or colon instead`;
+- Do NOT use em dashes or en dashes. Use a period, comma, or colon instead${corrective}`;
 
   const response = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -268,6 +275,7 @@ async function queuePost(textContent, twitterText, linkUrl, sourceType, sourceId
 async function main() {
   const { type, files, dryRun } = parseArgs();
   console.log(`=== Queue Social Posts (${type})${dryRun ? ' [dry run]' : ''} ===\n`);
+  let failures = 0;
 
   for (const filePath of files) {
     console.log(`Processing: ${filePath}`);
@@ -296,6 +304,26 @@ async function main() {
     try {
       postText = await generatePost(type, item);
       console.log(`  Generated post (${postText.length} chars): ${postText}`);
+
+      // Backstop for the one rewrite that turns a careful summary into a
+      // stronger claim than the reporting supports. Retry once with the miss
+      // spelled out; if it still flattens, publish nothing rather than an
+      // overstated fact, and fail the step so a human sees why.
+      let flattened = findFlattenedAttribution(getSummary(item), postText);
+      if (flattened) {
+        console.error(`  Dropped the "${flattened.marker}" ${flattened.kind} from the summary. Regenerating.`);
+        const corrective = `\n- The summary carries a ${flattened.kind} marker ("${flattened.marker}"). Your` +
+          ' previous attempt stated that claim as established fact. Keep the attribution or' +
+          ' hedge attached to the claim, or leave the claim out entirely.';
+        postText = await generatePost(type, item, corrective);
+        console.log(`  Regenerated post (${postText.length} chars): ${postText}`);
+        flattened = findFlattenedAttribution(getSummary(item), postText);
+      }
+      if (flattened) {
+        console.error(`  Skipping ${filePath}: still states the ${flattened.kind} claim ("${flattened.marker}") as fact.\n`);
+        failures++;
+        continue;
+      }
       const banks = resolveBanksFromCardNames(getCardNameList(item));
       if (banks.length > 0) {
         const withHandles = appendBankHandles(postText, banks, TWEET_TEXT_LIMIT);
@@ -346,6 +374,10 @@ async function main() {
   }
 
   console.log('=== Done ===');
+  if (failures > 0) {
+    console.error(`${failures} item(s) were not queued because the post overstated a hedged claim.`);
+    process.exitCode = 1;
+  }
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Problem

The Sapphire Reserve post published on 2026-09-02 read:

> This replaces the current $5 credit for restaurant orders only.

The summary it was generated from read:

> **Doctor of Credit reports** it takes the place of the current $5 restaurant only promo.

The hedge was the entire point of that sentence. Doctor of Credit and Upgraded Points disagree on whether the $5 promo survives, and DoorDash's own Chase page still lists it. The post asserted more than the reporting supports, on an account whose value is being factual.

## Fix, in two layers

**Prompt rule** (both `queue-social.js` and `post-social.js`): keep an outlet attribution or an uncertainty marker attached to the claim it governs, or drop the claim entirely. A company speaking about its own product ("Chase said", "Citi is mailing") is confirmation and may still be stated flatly, so the common case is untouched.

**Backstop** in `queue-social.js`, following the pattern already established for emoji and em dashes ("the prompt already forbids these; this is the backstop so a single ignored instruction cannot put an emoji in front of readers"):

- `findFlattenedAttribution(summary, text)` fires when the post repeats the substance of a hedged claim while carrying no hedge of its own.
- On a hit, it regenerates once with the specific miss spelled out.
- If the second attempt still flattens, the item is **not queued** and the step exits non-zero. Publishing nothing beats publishing an overstated fact, and CI shows why.

A prompt rule alone was not enough here: gpt-4o-mini restated the claim flatly on both attempts for this particular item.

## Avoiding over-blocking

The detector requires the claim to be **restated**, not merely that the summary contains a source name. A post that drops the hedged claim entirely is correct behaviour under the new prompt rule and passes.

An earlier revision of this patch got that wrong and would have blocked a perfectly good post that simply omitted the claim. That case is now pinned by a test.

First-party attributions are excluded from the source list by design, so "Southwest said on September 2" never trips it.

## Verification

- `node scripts/lib/social-text.test.js`: 15 tests pass, 9 new.
- Swept all 133 news summaries: **zero** would block a post that carries the summary's own hedging.
- Live dry runs:
  - Freedom Flex rumour item: kept `Rumor:` and `reports`, passed first try.
  - Amazon Prime shutdown: first attempt flattened, regenerated with `reportedly`, passed. The retry path working as intended.
  - Southwest lounges: no hedge, passed untouched.
  - Sapphire Reserve DoorDash: flattened on both attempts, correctly skipped, exit 1.

Affects future posts only.