### PR TITLE
Reddit Data Points 2026-09-04

### DIFF
--- a/data/reddit-datapoints/2026-09-04-t3_1w78wyq.yaml
+++ b/data/reddit-datapoints/2026-09-04-t3_1w78wyq.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1w78wyq"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1w78wyq/did_i_just_screw_up_by_closing_my_15_and_20_year/"
+posted: "2026-09-04"
+evidence: "Poster with an 842 FICO and $125k income reports a recent Ink Business Cash denial, with Chase citing unwillingness to extend more credit; they list five open cards after closing two old Citi accounts."
+card_name: "Ink Business Cash"
+result: "denied"
+credit_score: 842
+credit_score_source: 0
+listed_income: 125000
+total_open_cards: 5
+date_applied: "2026-09"
+reason_denied: "Chase declined to extend additional credit."
+reason_denied_code: "too_much_credit_with_issuer"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-09-04

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1w78wyq](https://www.reddit.com/r/CreditCards/comments/1w78wyq/did_i_just_screw_up_by_closing_my_15_and_20_year/) | Ink Business Cash | denied | 842 | $125,000 | — | — | 2026-09 | `2026-09-04-t3_1w78wyq.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (9)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [Applying for two credit cards back to back](https://www.reddit.com/r/CreditCards/comments/1w5bg9u/applying_for_two_credit_cards_back_to_back/) | Blue Cash Preferred · approved | credit_score | What was your score at the time, and which bureau? |
| [Applied for the wrong card](https://www.reddit.com/r/CreditCards/comments/1w5vlxz/applied_for_the_wrong_card/) | Discover it Cash Back · approved | credit_score | What was your score at the time, and which bureau? |
| [New Chase Sapphire Preferred has declined 6 legitimate purch…](https://www.reddit.com/r/CreditCards/comments/1w5uo24/new_chase_sapphire_preferred_has_declined_6/) | Chase Sapphire Preferred · approved | credit_score | What was your score at the time, and which bureau? |
| [Chase 5/24 timing, 5th card just hit 24 months but rejected,…](https://www.reddit.com/r/CreditCards/comments/1w5hi96/chase_524_timing_5th_card_just_hit_24_months_but/) | Ink Business Unlimited · denied | credit_score | What was your score at the time, and which bureau? |
| [BofA reconsideration success. Travel Rewards.](https://www.reddit.com/r/CreditCards/comments/1w5de2w/bofa_reconsideration_success_travel_rewards/) | Bank of America Travel Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [Approved for Sapphire Preferred!](https://www.reddit.com/r/CreditCards/comments/1w79ldo/approved_for_sapphire_preferred/) | Chase Sapphire Preferred · approved | credit_score | What was your score at the time, and which bureau? |
| [Strata Elite - false fraud alerts and frustrating Citi proce…](https://www.reddit.com/r/CreditCards/comments/1w786bb/strata_elite_false_fraud_alerts_and_frustrating/) | Citi Strata Elite · approved | credit_score | What was your score at the time, and which bureau? |
| [Typo on credit card application resulted in way less limit](https://www.reddit.com/r/CreditCards/comments/1w6oe5d/typo_on_credit_card_application_resulted_in_way/) | approved | card_name | Which card exactly was it? |
| [Bad Application Experience with Comenity/AAA Daily Advantage…](https://www.reddit.com/r/CreditCards/comments/1w6gcvf/bad_application_experience_with_comenityaaa_daily/) | AAA Daily Advantage Visa Signature · approved | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_outcome` | 10 | No stated approval or denial (odds question, recommendation request, chatter) |
| `no_score` | 2 | Real outcome but no credit score anywhere, and below the pending bar |


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
