### PR TITLE
Stop social posts truncating mid-word, and tag multi-card issuers

### DIFF
--- a/scripts/lib/bank-handles.js
+++ b/scripts/lib/bank-handles.js
@@ -90,6 +90,21 @@ function getBankHandles(bankNames) {
 }
 
 /**
+ * How many characters appendBankHandles would add for these banks: the "\n\n"
+ * join plus the handles themselves.
+ *
+ * Callers reserve this out of the text budget BEFORE generating. appendBankHandles
+ * drops handles (and returns the text untouched when even one will not fit), so a
+ * post generated against the full budget silently loses its issuer tag whenever
+ * the model fills the budget.
+ */
+function bankHandleSuffixLength(bankNames) {
+  const handles = getBankHandles(bankNames);
+  if (handles.length === 0) return 0;
+  return 2 + handles.join(' ').length; // "\n\n" + the handles
+}
+
+/**
  * Append bank @mentions to a tweet body, respecting a max-length ceiling.
  * Handles are joined with spaces on a new line (blank-line separated). If
  * adding all handles would push the tweet past `maxLength`, drops handles
@@ -118,5 +133,6 @@ module.exports = {
   getBankHandle,
   getBankHandles,
   appendBankHandles,
+  bankHandleSuffixLength,
   resolveBanksFromCardNames,
 };

--- a/scripts/lib/social-text.js
+++ b/scripts/lib/social-text.js
@@ -20,6 +20,21 @@ const URL_SEPARATOR_LENGTH = 2; // the "\n\n" between text and URL
 const TWEET_TEXT_LIMIT = TWEET_MAX - TCO_LENGTH - URL_SEPARATOR_LENGTH; // 255
 
 /**
+ * The shortest post worth keeping when truncation has to fall back to an
+ * earlier sentence boundary. A complete sentence this long still carries a
+ * fact; below it the post says nothing and the ellipsis is the lesser evil.
+ *
+ * This is an absolute floor rather than a fraction of the limit on purpose.
+ * A fraction rejects a clean break precisely when the text runs barely over
+ * budget, which is both the common case and the one where the mid-word
+ * fallback does the most damage. On 2026-09-04 a 259-character post (four
+ * over) had its only sentence break at 122, just under the old 127.5 guard,
+ * so it shipped cut mid-word as "and is not retro..." instead of stopping a
+ * sentence early.
+ */
+const MIN_TRUNCATED_LENGTH = 80;
+
+/**
  * Strip characters the house style bans, regardless of what the model returned.
  * The prompt already forbids these; this is the backstop so a single ignored
  * instruction cannot put an emoji or an em dash in front of readers.
@@ -62,7 +77,10 @@ function sanitizeSocialText(input) {
  * Sanitize, then hard-cap to the text budget. Truncation prefers the last
  * sentence or line break so a clipped post still ends on a complete fact
  * rather than mid-number; it falls back to an ellipsis only when there is no
- * clean break to cut at.
+ * usable break, and even then cuts on a word boundary.
+ *
+ * Truncation always costs a fact, so a caller that can regenerate should treat
+ * a post reaching this path as a retry signal, not as a finished post.
  */
 function enforceTweetLimit(input, limit = TWEET_TEXT_LIMIT) {
   const text = sanitizeSocialText(input);
@@ -74,13 +92,18 @@ function enforceTweetLimit(input, limit = TWEET_TEXT_LIMIT) {
     clipped.lastIndexOf('. '),
     clipped.lastIndexOf('.')
   );
-  // Prefer ending on a complete sentence or line. Accept the break as long as
-  // it keeps at least half the post; ending a fact short reads better than the
-  // ellipsis fallback, which can clip mid-number.
-  if (lastBreak >= limit * 0.5) {
+  // Prefer ending on a complete sentence or line whenever what remains still
+  // carries a fact. A short complete post beats a longer one that stops in the
+  // middle of a word, a number, or a negation.
+  if (lastBreak + 1 >= Math.min(MIN_TRUNCATED_LENGTH, limit)) {
     return clipped.slice(0, lastBreak + 1).trim().replace(/[\s,;:]+$/g, '');
   }
-  return `${clipped.slice(0, limit - 3).trim()}...`;
+  // No usable sentence break: clip at the last space so the ellipsis never
+  // splits a word in half.
+  const room = clipped.slice(0, limit - 3).trimEnd();
+  const lastSpace = room.lastIndexOf(' ');
+  const body = lastSpace >= MIN_TRUNCATED_LENGTH ? room.slice(0, lastSpace) : room;
+  return `${body.trimEnd().replace(/[\s,;:]+$/g, '')}...`;
 }
 
 /**
@@ -232,5 +255,5 @@ function findFlattenedAttribution(summary, text) {
   return null;
 }
 
-module.exports = { TWEET_TEXT_LIMIT, TWEET_MAX, sanitizeSocialText, enforceTweetLimit,
-  findFlattenedAttribution, THIRD_PARTY_SOURCES, UNCERTAINTY_MARKERS };
+module.exports = { TWEET_TEXT_LIMIT, TWEET_MAX, MIN_TRUNCATED_LENGTH, sanitizeSocialText,
+  enforceTweetLimit, findFlattenedAttribution, THIRD_PARTY_SOURCES, UNCERTAINTY_MARKERS };

--- a/scripts/lib/social-text.test.js
+++ b/scripts/lib/social-text.test.js
@@ -21,6 +21,7 @@ const assert = require('node:assert/strict');
 const {
   TWEET_TEXT_LIMIT,
   TWEET_MAX,
+  MIN_TRUNCATED_LENGTH,
   sanitizeSocialText,
   enforceTweetLimit,
   findFlattenedAttribution,
@@ -116,6 +117,42 @@ test('a lone early sentence boundary is preferred over an ellipsis', () => {
   const out = enforceTweetLimit(`${lead} ${'y'.repeat(200)} trailing words`);
   assert.equal(out, lead, `did not cut back to the lead sentence: ${out}`);
   assert.ok(!out.endsWith('...'), 'fell back to ellipsis despite a clean break');
+});
+
+// The exact post that shipped truncated on 2026-09-04 (queue id 398). The
+// model came in at 259 characters, four over budget, and the only sentence
+// break sat at 122 -- just under the old `limit * 0.5` guard -- so the clean
+// break was rejected and the ellipsis fallback cut inside "retroactive",
+// destroying the negation the sentence existed to deliver.
+test('a barely-over post cuts back to its sentence instead of mid-word', () => {
+  const shipped =
+    "NEW: Discover's Q4 2026 rotating categories for October through December " +
+    'include restaurants, entertainment, and utilities. The 5% cashback applies ' +
+    'to up to $1,500 in combined purchases after activation, which opened ' +
+    'September 1, 2026, and is not retroactive.';
+  assert.ok(shipped.length > TWEET_TEXT_LIMIT, 'fixture is no longer over budget');
+  const out = enforceTweetLimit(shipped);
+  assert.ok(out.length <= TWEET_TEXT_LIMIT);
+  assert.ok(!out.endsWith('...'), `fell back to an ellipsis: ${out}`);
+  assert.ok(out.endsWith('utilities.'), `did not end on the lead sentence: ${out}`);
+  assert.ok(!/retro$/.test(out), 'still clipped mid-word');
+});
+
+// The floor is absolute, so a clean break is taken wherever it lands above it.
+test('a sentence break just above the floor is still preferred', () => {
+  const lead = `NEW: ${'x'.repeat(MIN_TRUNCATED_LENGTH - 6)}.`;
+  assert.equal(lead.length, MIN_TRUNCATED_LENGTH);
+  const out = enforceTweetLimit(`${lead} ${'y'.repeat(300)}`);
+  assert.equal(out, lead, `did not cut back to the lead sentence: ${out}`);
+});
+
+// Below the floor there is no fact left to keep, so the ellipsis wins -- but it
+// must still land between words rather than inside one.
+test('the ellipsis fallback cuts on a word boundary', () => {
+  const out = enforceTweetLimit(`${'word '.repeat(80)}retroactive`, 120);
+  assert.ok(out.length <= 120);
+  assert.ok(out.endsWith('...'));
+  assert.ok(/word\.\.\.$/.test(out), `split a word: ${out}`);
 });
 
 test('text with no clean break falls back to an ellipsis within the limit', () => {

--- a/scripts/post-social.js
+++ b/scripts/post-social.js
@@ -69,6 +69,13 @@ function buildUrl(type, item) {
  */
 function getCardNameList(item) {
   if (item.card_name) return [item.card_name];
+  // Multi-card items carry card_names (plural), the field build-news.js
+  // validates against card_slugs. Missing it here meant a third of news items
+  // reached the model with "Cards: N/A" and resolved no bank, so they could
+  // never be tagged with their issuer handle.
+  if (Array.isArray(item.card_names) && item.card_names.length > 0) {
+    return item.card_names.slice();
+  }
   if (Array.isArray(item.related_cards) && item.related_cards.length > 0) {
     return item.related_cards.slice();
   }

--- a/scripts/queue-social.js
+++ b/scripts/queue-social.js
@@ -15,8 +15,8 @@
 
 const fs = require('fs');
 const yaml = require('js-yaml');
-const { appendBankHandles, resolveBanksFromCardNames } = require('./lib/bank-handles');
-const { TWEET_TEXT_LIMIT, enforceTweetLimit, findFlattenedAttribution } = require('./lib/social-text');
+const { appendBankHandles, bankHandleSuffixLength, resolveBanksFromCardNames } = require('./lib/bank-handles');
+const { TWEET_TEXT_LIMIT, sanitizeSocialText, enforceTweetLimit, findFlattenedAttribution } = require('./lib/social-text');
 
 async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -108,6 +108,13 @@ function getSummary(item) {
 
 function getCardNameList(item) {
   if (item.card_name) return [item.card_name];
+  // Multi-card items carry card_names (plural), the field build-news.js
+  // validates against card_slugs. Missing it here meant a third of news items
+  // reached the model with "Cards: N/A" and resolved no bank, so they could
+  // never be tagged with their issuer handle.
+  if (Array.isArray(item.card_names) && item.card_names.length > 0) {
+    return item.card_names.slice();
+  }
   if (Array.isArray(item.related_cards) && item.related_cards.length > 0) {
     return item.related_cards.slice();
   }
@@ -119,7 +126,7 @@ function getCardNameList(item) {
   return [];
 }
 
-async function generatePost(type, item, corrective = '') {
+async function generatePost(type, item, corrective = '', limit = TWEET_TEXT_LIMIT) {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) throw new Error('OPENAI_API_KEY is required');
 
@@ -146,7 +153,7 @@ Voice: a factual trade-desk account. Informative and specific, never promotional
 and never meme-y. The reader should finish the post knowing the concrete facts.
 
 Rules:
-- Hard limit ${TWEET_TEXT_LIMIT} characters. Aim for 200 to 230: anything over the limit is
+- Hard limit ${limit} characters. Aim for ${Math.max(120, limit - 55)} to ${Math.max(140, limit - 25)}: anything over the limit is
   cut off mid-sentence, so finish the thought inside the budget. Do not pad to
   fill it, and do not compress facts out to be short
 - Default to a single paragraph of plain sentences. Line breaks are for lists,
@@ -203,7 +210,12 @@ Rules:
   const data = await response.json();
   // Strips banned characters (emoji, em dashes) and caps at the real text
   // budget, which leaves room for the t.co link appended at post time.
-  return enforceTweetLimit(data.choices[0]?.message?.content || '');
+  //
+  // rawLength is the sanitized length BEFORE capping. Capping is lossy, so the
+  // caller needs to see the overshoot to decide whether to regenerate; folding
+  // it in here silently destroyed that signal.
+  const raw = sanitizeSocialText(data.choices[0]?.message?.content || '');
+  return { text: enforceTweetLimit(raw, limit), rawLength: raw.length, limit };
 }
 
 // Fetch a remote image and return { base64, mimeType } suitable for the
@@ -302,8 +314,31 @@ async function main() {
     let postText;
     let twitterText = null;
     try {
-      postText = await generatePost(type, item);
-      console.log(`  Generated post (${postText.length} chars): ${postText}`);
+      // Reserve the issuer handles out of the budget up front. appendBankHandles
+      // only ever appends what is left over, so a post generated against the full
+      // 255 and landing at 255 silently ships with no @issuer tag at all.
+      const banks = resolveBanksFromCardNames(getCardNameList(item));
+      const textLimit = TWEET_TEXT_LIMIT - bankHandleSuffixLength(banks);
+
+      let generated = await generatePost(type, item, '', textLimit);
+      console.log(`  Generated post (${generated.text.length} chars): ${generated.text}`);
+
+      // Overshooting the budget is recoverable and truncation is not: capping
+      // always drops a fact, and on 2026-09-04 a four-character overshoot cost
+      // the post its closing clause. Ask once for a shorter version before
+      // settling for the capped text.
+      if (generated.rawLength > textLimit) {
+        console.error(`  Generated ${generated.rawLength} chars against a ${textLimit} char budget. Regenerating.`);
+        const corrective = `\n- Your previous attempt was ${generated.rawLength} characters against a ` +
+          `${textLimit} character budget. Rewrite it to fit inside ${textLimit} characters while keeping ` +
+          'the concrete facts, and finish the closing sentence. Do not end mid-sentence.';
+        const retry = await generatePost(type, item, corrective, textLimit);
+        console.log(`  Regenerated post (${retry.text.length} chars): ${retry.text}`);
+        // Keep the retry when it fits, or when it at least overshoots by less.
+        // A retry that runs even longer is a worse cap, so keep the first.
+        if (retry.rawLength <= generated.rawLength) generated = retry;
+      }
+      postText = generated.text;
 
       // Backstop for the one rewrite that turns a careful summary into a
       // stronger claim than the reporting supports. Retry once with the miss
@@ -315,7 +350,7 @@ async function main() {
         const corrective = `\n- The summary carries a ${flattened.kind} marker ("${flattened.marker}"). Your` +
           ' previous attempt stated that claim as established fact. Keep the attribution or' +
           ' hedge attached to the claim, or leave the claim out entirely.';
-        postText = await generatePost(type, item, corrective);
+        postText = (await generatePost(type, item, corrective, textLimit)).text;
         console.log(`  Regenerated post (${postText.length} chars): ${postText}`);
         flattened = findFlattenedAttribution(getSummary(item), postText);
       }
@@ -324,7 +359,6 @@ async function main() {
         failures++;
         continue;
       }
-      const banks = resolveBanksFromCardNames(getCardNameList(item));
       if (banks.length > 0) {
         const withHandles = appendBankHandles(postText, banks, TWEET_TEXT_LIMIT);
         if (withHandles !== postText) {


### PR DESCRIPTION
## The bug

The Discover Q4 post queued on 2026-09-04 (queue id 398) shipped as:

> NEW: Discover's Q4 2026 rotating categories for October through December include restaurants, entertainment, and utilities. The 5% cashback applies to up to $1,500 in combined purchases after activation, which opened September 1, 2026, and is not retro...

It cut inside "retroactive", destroying the negation the sentence existed to deliver, and it carried no `@Discover` tag. Three defects lined up.

### 1. The truncation guard fired where its fallback hurts most

`enforceTweetLimit` only accepted a sentence break past `limit * 0.5`. The model returned 259 chars against a 255 budget, **four over**, and the only sentence break sat at index 122 against a 127.5 threshold. Missing by five characters rejected the clean cut and fell through to an ellipsis that slices at a fixed offset, mid-word.

The guard existed to stop a post being gutted to a fragment, but a fraction of the limit rejects a clean break precisely when the text runs *barely* over, which is both the common case and the one where the mid-word fallback is worst. It is now an absolute floor (`MIN_TRUNCATED_LENGTH = 80`), and the ellipsis path clips at the last space so it can never split a word.

### 2. The overshoot signal was destroyed before anyone could act on it

`generatePost` applied `enforceTweetLimit` to its own return value, so the caller could not tell a comfortable post from one that had just lost a clause. A recoverable four-character overshoot became an unrecoverable lost fact.

It now returns `{ text, rawLength, limit }`, and the caller retries once with the budget spelled out, mirroring the attribution retry already sitting a few lines below. Truncation goes back to being the backstop it was meant to be.

### 3. Multi-card items were never tagged with their issuer

`getCardNameList` reads `card_name`, `related_cards` and `cards`, but not `card_names` (plural), the multi-card field `build-news.js` validates against `card_slugs`. **33 of 97 news items use it.** All of them reached the model with `Cards: N/A` and resolved no bank, so they could never be tagged. Fixed in both `queue-social.js` and `post-social.js`.

The budget also now reserves room for the handles before generating, since `appendBankHandles` is a silent no-op once the text already fills the limit.

## Verification

Dry run against the same item, before and after:

```
before:  Generated post (255 chars): ...and is not retro...
         (no Twitter variant, no handle)

after:   Generated post (155 chars): [complete sentence]
         Generated 289 chars against a 244 char budget. Regenerating.
         Regenerated post (121 chars): [complete, in budget]
         Twitter variant (132 chars): ... @Discover
```

Also dry-ran a single-card item carrying a `Doctor of Credit` attribution to confirm the length retry chains correctly into the attribution backstop, which still skips the item rather than publishing a flattened claim.

Three regression tests added to `scripts/lib/social-text.test.js`, including the exact shipped string as a fixture. All existing tests pass.

## Note

`scripts/lib/social-text.test.js` is not wired into CI, so none of these tests run on a PR. Worth a follow-up.
