### PR TITLE
Auto: Intuit Business rewards/benefits update — 2026-09-06

### DIFF
--- a/data/cards/intuit-business.yaml
+++ b/data/cards/intuit-business.yaml
@@ -52,6 +52,12 @@ benefits:
     value: 0
     frequency: "one_time"
     category: "other"
+  - name: "Business Partner Discounts"
+    value: 0
+    description: "Intuit-negotiated cardholder savings including 30% off the first year of Google Workspace Business Standard, 25% off Adobe Creative Cloud Pro, 25% off LegalZoom business services, up to 42% off FedEx shipping, and up to $400 in annual LinkedIn Hiring Pro credits"
+    frequency: "ongoing"
+    category: "other"
+    enrollment_required: false
 our_take: >
   If your business already runs on QuickBooks, this card's real selling point
   is not the rewards but the plumbing: transactions and captured receipts flow


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Intuit Business**.

**Apply link (verify against this):** https://www.intuit.com/credit-card/

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
