### PR TITLE
Auto: Truist Enjoy Beyond rewards/benefits update — 2026-09-06

### DIFF
--- a/data/cards/truist-enjoy-beyond.yaml
+++ b/data/cards/truist-enjoy-beyond.yaml
@@ -55,6 +55,12 @@ benefits:
     description: "10% to 50% bonus on points redeemed into an eligible Truist deposit account, with the tier set by your combined Truist balances"
     frequency: "per_redemption"
     category: "rewards"
+  - name: "Annual Fee Waiver for Truist Wealth Clients"
+    value: 0
+    description: "The $95 annual fee is waived when an account holder is a Truist Wealth client (Signature, Reserve, or GenSpring) with an assigned Truist Wealth advisor at the time the fee is charged"
+    frequency: "annual"
+    category: "other"
+    enrollment_required: false
 apply_link: https://www.truist.com/credit-cards/enjoy-beyond
 our_take: >
   Enjoy Beyond pays 3x points on airlines, hotels, and car rentals and 2x on


### PR DESCRIPTION
The weekly rewards-and-benefits check picked up changes on the apply page for **Truist Enjoy Beyond**.

**Apply link (verify against this):** https://www.truist.com/credit-cards/enjoy-beyond

Opened by `scripts/check-card-rewards-and-benefits.js` via the local `card-rewards-benefits-local` routine. Only changes that passed the editorial filter in `data/benefit-policy.yaml` are here; borderline items were routed to the weekly review issue instead, and benefits previously removed from this card were skipped.

Review against the live apply page before merging.
