### PR TITLE
Reddit Data Points 2026-09-07

### DIFF
--- a/data/reddit-datapoints/2026-09-07-t3_1w93qad.yaml
+++ b/data/reddit-datapoints/2026-09-07-t3_1w93qad.yaml
@@ -1,0 +1,13 @@
+source_id: "t3_1w93qad"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1w93qad/looking_for_new_travel_card/"
+posted: "2026-09-06"
+evidence: "In a card-recommendation profile the poster reports applying for the Sapphire Preferred on 7/24/26 and being denied for too many recently opened cards, listing FICOs of Experian 723, TransUnion 740, Equifax 721 and $40k income."
+card_name: "Chase Sapphire Preferred"
+result: "denied"
+credit_score: 723
+credit_score_source: 1
+listed_income: 40000
+length_credit: 1
+date_applied: "2026-07"
+reason_denied: "Chase cited too many accounts opened recently."
+reason_denied_code: "too_many_recent_accounts"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-09-07

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1w93qad](https://www.reddit.com/r/CreditCards/comments/1w93qad/looking_for_new_travel_card/) | Chase Sapphire Preferred | denied | 723 | $40,000 | — | 1 | 2026-07 | `2026-09-07-t3_1w93qad.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (11)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [BofA reconsideration success. Travel Rewards.](https://www.reddit.com/r/CreditCards/comments/1w5de2w/bofa_reconsideration_success_travel_rewards/) | Bank of America Travel Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [Approved for Sapphire Preferred!](https://www.reddit.com/r/CreditCards/comments/1w79ldo/approved_for_sapphire_preferred/) | Chase Sapphire Preferred · approved | credit_score | What was your score at the time, and which bureau? |
| [Chase 5/24 timing, 5th card just hit 24 months but rejected,…](https://www.reddit.com/r/CreditCards/comments/1w5hi96/chase_524_timing_5th_card_just_hit_24_months_but/) | Ink Business Unlimited · denied | credit_score | What was your score at the time, and which bureau? |
| [Strata Elite - false fraud alerts and frustrating Citi proce…](https://www.reddit.com/r/CreditCards/comments/1w786bb/strata_elite_false_fraud_alerts_and_frustrating/) | Citi Strata Elite · approved | credit_score | What was your score at the time, and which bureau? |
| [Typo on credit card application resulted in way less limit](https://www.reddit.com/r/CreditCards/comments/1w6oe5d/typo_on_credit_card_application_resulted_in_way/) | approved | card_name | Which card exactly was it? |
| [Bad Application Experience with Comenity/AAA Daily Advantage…](https://www.reddit.com/r/CreditCards/comments/1w6gcvf/bad_application_experience_with_comenityaaa_daily/) | AAA Daily Advantage Visa Signature · approved | credit_score | What was your score at the time, and which bureau? |
| [Bilt just gave me a reason to question whether I should trus…](https://www.reddit.com/r/CreditCards/comments/1w813zi/bilt_just_gave_me_a_reason_to_question_whether_i/) | Bilt Obsidian · approved | credit_score | What was your score at the time, and which bureau? |
| [Chase Reconsideration Experience](https://www.reddit.com/r/CreditCards/comments/1w90jir/chase_reconsideration_experience/) | Ink Business Unlimited · approved | credit_score | What was your score at the time, and which bureau? |
| [Robinhood Gold Credit Card](https://www.reddit.com/r/CreditCards/comments/1w8pxa7/robinhood_gold_credit_card/) | Robinhood Gold · approved | credit_score | What was your score at the time, and which bureau? |
| [Citi AA Plat select recon?](https://www.reddit.com/r/CreditCards/comments/1w8bbwq/citi_aa_plat_select_recon/) | Citi AAdvantage Platinum Select World Elite Mastercard · denied | credit_score | What was your score at the time, and which bureau? |
| [American Airlines credit card question.](https://www.reddit.com/r/CreditCards/comments/1w97vrt/american_airlines_credit_card_question/) | Citi AAdvantage Platinum Select World Elite Mastercard · approved | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_outcome` | 7 | No stated approval or denial (odds question, recommendation request, chatter) |
| `no_score` | 2 | Real outcome but no credit score anywhere, and below the pending bar |
| `card_unclear` | 1 | Real outcome but which card was applied for cannot be pinned down |
| `duplicate` | 1 | Same application already recorded |


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
