### PR TITLE
Reddit Data Points 2026-09-09

### DIFF
--- a/data/reddit-datapoints/2026-09-09-t3_1wb4ltb.yaml
+++ b/data/reddit-datapoints/2026-09-09-t3_1wb4ltb.yaml
@@ -1,0 +1,15 @@
+source_id: "t3_1wb4ltb"
+permalink: "https://www.reddit.com/r/CreditCards/comments/1wb4ltb/major_disappointment_with_navy_federal/"
+posted: "2026-09-08"
+evidence: "Poster reports a Navy Federal Platinum approval for a $7,000 limit at 17.5% APR with a FICO in the 810 to 820 range, $145k income, two existing cards, no inquiries or new accounts in ten years, and a ten year Navy Federal checking relationship."
+card_name: "Navy Federal Platinum"
+result: "approved"
+credit_score: 810
+credit_score_source: 0
+listed_income: 145000
+starting_credit_limit: 7000
+total_open_cards: 2
+inquiries_12: 0
+inquiries_24: 0
+bank_customer: true
+date_applied: "2026-09"


### PR DESCRIPTION
## Proposed Reddit data points — 2026-09-09

Extracted from public r/CreditCards posts by the daily `reddit-datapoints-local` task. Each row below is one file in `data/reddit-datapoints/`; the `evidence` line inside each file says what the post reports.

| Source | Card | Result | Score | Income | Limit | History (yrs) | Applied | File |
|---|---|---|---|---|---|---|---|---|
| [t3_1wb4ltb](https://www.reddit.com/r/CreditCards/comments/1wb4ltb/major_disappointment_with_navy_federal/) | Navy Federal Platinum | approved | 810 | $145,000 | $7,000 | — | 2026-09 | `2026-09-09-t3_1wb4ltb.yaml` |

### How to review
1. Spot-check rows against their source links (each Source cell links to the Reddit post).
2. **Reject a row** by deleting its file from this PR (GitHub → Files changed → ⋯ → Delete file). Rejected sources are never re-proposed — the seen-state was already recorded.
3. **Reject everything** by closing the PR.
4. **Accept the rest by merging.**

### Needs one more field (14)

Real first-person outcomes we could not publish. Later runs re-read each post for 7 days or 3 looks in case the poster answers in a comment. Nothing here is a file in this PR, and merging does not change them — this is the list to ask about by hand if you want to.

| Post | Established | Missing | Suggested ask |
|---|---|---|---|
| [Strata Elite - false fraud alerts and frustrating Citi proce…](https://www.reddit.com/r/CreditCards/comments/1w786bb/strata_elite_false_fraud_alerts_and_frustrating/) | Citi Strata Elite · approved | credit_score | What was your score at the time, and which bureau? |
| [Typo on credit card application resulted in way less limit](https://www.reddit.com/r/CreditCards/comments/1w6oe5d/typo_on_credit_card_application_resulted_in_way/) | approved | card_name | Which card exactly was it? |
| [Chase 5/24 timing, 5th card just hit 24 months but rejected,…](https://www.reddit.com/r/CreditCards/comments/1w5hi96/chase_524_timing_5th_card_just_hit_24_months_but/) | Ink Business Unlimited · denied | credit_score | What was your score at the time, and which bureau? |
| [Bad Application Experience with Comenity/AAA Daily Advantage…](https://www.reddit.com/r/CreditCards/comments/1w6gcvf/bad_application_experience_with_comenityaaa_daily/) | AAA Daily Advantage Visa Signature · approved | credit_score | What was your score at the time, and which bureau? |
| [Bilt just gave me a reason to question whether I should trus…](https://www.reddit.com/r/CreditCards/comments/1w813zi/bilt_just_gave_me_a_reason_to_question_whether_i/) | Bilt Obsidian · approved | credit_score | What was your score at the time, and which bureau? |
| [Chase Reconsideration Experience](https://www.reddit.com/r/CreditCards/comments/1w90jir/chase_reconsideration_experience/) | Ink Business Unlimited · approved | credit_score | What was your score at the time, and which bureau? |
| [Robinhood Gold Credit Card](https://www.reddit.com/r/CreditCards/comments/1w8pxa7/robinhood_gold_credit_card/) | Robinhood Gold · approved | credit_score | What was your score at the time, and which bureau? |
| [Citi AA Plat select recon?](https://www.reddit.com/r/CreditCards/comments/1w8bbwq/citi_aa_plat_select_recon/) | Citi AAdvantage Platinum Select World Elite Mastercard · denied | credit_score | What was your score at the time, and which bureau? |
| [American Airlines credit card question.](https://www.reddit.com/r/CreditCards/comments/1w97vrt/american_airlines_credit_card_question/) | Citi AAdvantage Platinum Select World Elite Mastercard · approved | credit_score | What was your score at the time, and which bureau? |
| [Citi AAdvantage $400 + 40,000 miles offer on AA.com: approve…](https://www.reddit.com/r/CreditCards/comments/1wbm0aj/citi_aadvantage_400_40000_miles_offer_on_aacom/) | Citi AAdvantage Platinum Select World Elite Mastercard · approved | credit_score | What was your score at the time, and which bureau? |
| [Does cap1 spark biz cc have reconsideration line?](https://www.reddit.com/r/CreditCards/comments/1wbfvjc/does_cap1_spark_biz_cc_have_reconsideration_line/) | denied | card_name | Which card exactly was it? |
| [How do I know if I got the Rakuten deal with BoA UCR?](https://www.reddit.com/r/CreditCards/comments/1wb0t2o/how_do_i_know_if_i_got_the_rakuten_deal_with_boa/) | Bank of America Travel Rewards · approved | credit_score | What was your score at the time, and which bureau? |
| [Chase not letting me talk to someone in reconsideration depa…](https://www.reddit.com/r/CreditCards/comments/1wb0hwr/chase_not_letting_me_talk_to_someone_in/) | Chase Freedom Unlimited · denied | credit_score | What was your score at the time, and which bureau? |
| [Chase Amazon Prime Visa rejected after recently moving to th…](https://www.reddit.com/r/CreditCards/comments/1waemr2/chase_amazon_prime_visa_rejected_after_recently/) | Amazon Prime Rewards Visa Signature · denied | credit_score | What was your score at the time, and which bureau? |
### Candidates that produced nothing

| Reason | Count | Meaning |
|---|---|---|
| `no_outcome` | 12 | No stated approval or denial (odds question, recommendation request, chatter) |
| `no_score` | 5 | Real outcome but no credit score anywhere, and below the pending bar |
| `pre_qual` | 3 | Pre-qualification or pre-approval result, which is never an outcome |

**Cards in real data points but missing from the catalog:** `Destiny Mastercard`. Adding one turns every future post about it into publishable odds data.


### What merging does
`sync-datapoints.yml` invokes the `creditodds-import-reddit-records` Lambda, which inserts the accepted rows into the `records` table (submitter_id `reddit:<source_id>`, so imports are distinguishable and idempotent). Card stats refresh within ~5 minutes; CloudFront/ISR caching means public pages update within ~10.
