### PR TITLE
reddit-datapoints: widen request spacing and cap the pending bucket

### DIFF
--- a/scripts/check-reddit-datapoints.js
+++ b/scripts/check-reddit-datapoints.js
@@ -109,6 +109,20 @@ const MAX_SCORE_RANGE_SPREAD = 20;
 const PENDING_MAX_DAYS = 7;
 const PENDING_MAX_ATTEMPTS = 3;
 
+// How many entries the bucket may hold at once.
+//
+// The other two bounds age an entry out; this one stops the bucket growing past
+// what a run can actually service. Every entry costs one comment-feed request
+// per look, drawn from CAPS.replyRequests and shared with fresh OP expansion,
+// so a bucket bigger than the revisit budget does not chase harder — it just
+// means entries reach PENDING_MAX_DAYS without ever being looked at, which
+// reads in the follow-up list exactly like "we asked and got nothing".
+// Live on 2026-09-09: 14 entries against 6 revisit slots, of which Reddit's
+// 429s let through 2. Sized a little above CAPS.revisitPosts so a full bucket
+// still drains in about a run, with headroom for the entries that get skipped
+// when the feed throttles.
+const PENDING_MAX_ENTRIES = 8;
+
 // Fields a pending entry may claim to be missing. Anything the extraction rules
 // treat as required to publish a row, plus card_name for the case where the
 // outcome is unambiguous but which card it was is not.
@@ -211,7 +225,17 @@ const CAPS = {
   abortAfterThrottled: 3,
   // Timings, named so the tests can shrink them — otherwise every case that
   // exercises the retry or the request loop would sit through the real waits.
-  requestSpacingMs: 8000,
+  //
+  // Raised 8s → 15s on 2026-09-09. 8s was cheap per request but not actually
+  // cheaper per run: three unauthenticated local routines share this IP
+  // (card-news-local and reddit-product-changes-local are the other two), and
+  // on 2026-09-09 the fetch phase took five 61s backoffs, lost /new page 2 and
+  // the megathread outright, and reached only 2 of 5 pending revisits. A
+  // backoff costs 61s, so trading ~7s of spacing to avoid even one of them wins
+  // on wall-clock as well as on coverage: ~13 requests at 15s is ~3.3 minutes,
+  // inside the 3-5 minute budget the routine already claims, where the same run
+  // at 8s spent 305s in backoffs alone.
+  requestSpacingMs: 15000,
   rateLimitBackoffMs: 61000,
 };
 
@@ -888,6 +912,8 @@ Declare an entry pending ONLY when **all** of these hold:
 
 A "what are my odds?" post, a recommendation-template post, or a pre-qual rejection is NOT pending. It is a skip, same as before. The bucket is expensive (one Reddit request per entry per run, against a feed that throttles us) and it is only worth spending on a row we would publish the moment one number arrives.
 
+The bucket holds ${PENDING_MAX_ENTRIES} entries at most, and entries already being chased keep their places. So on a busy day the last few new near-misses you declare will not be admitted: they are reported with their links for a human to ask by hand, but they get no automatic revisits. Write the strongest ones first, and do not pad the bucket to look thorough — a weak entry admitted is a strong one refused.
+
 \`note\` is your own paraphrase and gets read by a human deciding whether to go ask the poster, so say what is established and what is missing in one line.
 
 \`ask\` is optional and overrides the generic per-field question in the follow-up list. Write one whenever the post says something adjacent to the missing field, because the generic question will otherwise ask for what the post already gives: if the poster wrote "mid 700s", the ask is "you said mid 700s, what was the exact number?", not "what was your score?". Skip \`ask\` when the field is simply absent and the generic question already fits.
@@ -1309,7 +1335,28 @@ function mergePending({ carried, declared, candidateById }) {
     pending[id] = entry.firstSeen ? entry : { ...entry, firstSeen: TODAY };
     carriedForward.push({ id, entry: pending[id] });
   }
-  return { pending, carriedForward };
+
+  // Enforce PENDING_MAX_ENTRIES as admission control on THIS run's brand-new
+  // near-misses, never on entries already in flight.
+  //
+  // Evicting an in-flight entry instead would undo the 2026-08-13 starvation
+  // fix in rankPending: those are the entries with attempts already spent and
+  // the least time left, so dropping them wastes every request spent on them so
+  // far and re-creates the "nothing ever reaches its third look" failure. A
+  // brand-new entry, by contrast, has cost nothing yet — refusing it is the
+  // cheapest possible eviction, and it is what keeps a busy day from burying
+  // yesterday's half-chased entries.
+  //
+  // A refused entry is NOT silently lost: it is returned so the run report can
+  // print it with its link, the same as any other follow-up. It just does not
+  // get automatic revisits, so it is Max's to ask by hand or let go.
+  const notAdmitted = [];
+  const fresh = Object.keys(declared).filter((id) => !carried[id]);
+  for (let i = fresh.length - 1; i >= 0 && Object.keys(pending).length > PENDING_MAX_ENTRIES; i -= 1) {
+    notAdmitted.unshift({ id: fresh[i], entry: pending[fresh[i]] });
+    delete pending[fresh[i]];
+  }
+  return { pending, carriedForward, notAdmitted };
 }
 
 // The staged state is the fetch phase's output, so finish has to read it back,
@@ -1352,12 +1399,19 @@ function reconcilePending(validationCtx) {
     };
   }
 
-  const { pending, carriedForward } = mergePending({
+  const { pending, carriedForward, notAdmitted } = mergePending({
     carried,
     declared,
     candidateById: validationCtx.candidateById,
   });
-  return { staged, pending, rejected, carriedForward, carriedCount: Object.keys(carried).length };
+  return {
+    staged,
+    pending,
+    rejected,
+    carriedForward,
+    notAdmitted,
+    carriedCount: Object.keys(carried).length,
+  };
 }
 
 function resolvePendingFor(result, publishedIds) {
@@ -1373,7 +1427,7 @@ function resolvePendingFor(result, publishedIds) {
 // `runs` is the completed run log; the staging-only `run` key is dropped here,
 // so what lands in the committed state file stays {seen, pending, runs}.
 function reportPending(result, runs) {
-  const { staged, pending, rejected, resolved = 0, carriedForward = [] } = result;
+  const { staged, pending, rejected, resolved = 0, carriedForward = [], notAdmitted = [] } = result;
   fs.writeFileSync(
     STATE_UPDATED_FILE,
     `${JSON.stringify({ seen: staged.seen || {}, pending, runs: runs || staged.runs || [] }, null, 2)}\n`
@@ -1399,6 +1453,19 @@ function reportPending(result, runs) {
           `still ${looksLeft} look(s) left, first seen ${entry.firstSeen}`
       );
       console.log(`    ${entry.url}`);
+    }
+  }
+
+  if (notAdmitted.length > 0) {
+    console.log(
+      `\nPending bucket full (${PENDING_MAX_ENTRIES}): ${notAdmitted.length} new near-miss(es) not admitted, ` +
+        `so they get no automatic revisits. Ask by hand or let them go:`
+    );
+    for (const { id, entry } of notAdmitted) {
+      const known = [entry.card_name, entry.result].filter(Boolean).join(' ') || 'outcome';
+      console.log(`  - ${known}, missing ${(entry.missing || []).join('/')}`);
+      if (entry.url) console.log(`    ${entry.url}`);
+      if (entry.note) console.log(`    ${entry.note}`);
     }
   }
 
@@ -1847,6 +1914,7 @@ module.exports = {
   buildRunEntry,
   fetchNewPosts,
   SKIP_REASONS,
+  PENDING_MAX_ENTRIES,
   RUN_LOG_LIMIT,
   NEW_FEED_PAGES,
   CAPS,

--- a/scripts/check-reddit-datapoints.test.js
+++ b/scripts/check-reddit-datapoints.test.js
@@ -27,6 +27,7 @@ const {
   rankPending,
   validatePendingEntry,
   mergePending,
+  PENDING_MAX_ENTRIES,
   buildFollowups,
   fetchNewPosts,
   loadSkipped,
@@ -625,6 +626,75 @@ test('a re-declared entry wins over the carried copy', () => {
   assert.equal(pending.t3_shown.attempts, 2);
   assert.equal(pending.t3_shown.note, 'still no score');
   assert.deepEqual(carriedForward, [], 'a re-declared entry was presented, so it is not a carry');
+});
+
+// PENDING_MAX_ENTRIES bounds the bucket to what a run can actually service.
+// Eviction has to fall on brand-new entries, never on ones already part-chased,
+// or a busy day would keep resetting the bucket and nothing would ever finish.
+const nearMiss = (n, extra = {}) => ({
+  url: `https://reddit.com/${n}`,
+  missing: ['credit_score'],
+  firstSeen: '2026-09-09',
+  attempts: 1,
+  ...extra,
+});
+
+test('a full bucket refuses new near-misses instead of growing', () => {
+  const declared = {};
+  for (let i = 0; i < PENDING_MAX_ENTRIES + 3; i += 1) declared[`t3_new${i}`] = nearMiss(i);
+
+  const { pending, notAdmitted } = mergePending({ carried: {}, declared, candidateById: new Map() });
+
+  assert.equal(Object.keys(pending).length, PENDING_MAX_ENTRIES, 'bucket is capped');
+  assert.equal(notAdmitted.length, 3, 'the overflow is reported, not dropped in silence');
+  // The tail overflows, so the earlier files survive and the report keeps them
+  // in file order rather than reversed.
+  assert.deepEqual(
+    notAdmitted.map((n) => n.id),
+    ['t3_new8', 't3_new9', 't3_new10']
+  );
+  assert.ok(notAdmitted.every((n) => n.entry && n.entry.url), 'refused entries keep their link for the ask-list');
+});
+
+test('the cap evicts brand-new entries, never ones already in flight', () => {
+  // A full bucket of part-chased entries, plus a fresh near-miss on top.
+  const carried = {};
+  const candidateById = new Map();
+  for (let i = 0; i < PENDING_MAX_ENTRIES; i += 1) {
+    carried[`t3_old${i}`] = nearMiss(i, { firstSeen: '2026-09-05', attempts: 2 });
+  }
+  const declared = { t3_fresh: nearMiss('fresh') };
+
+  const { pending, notAdmitted } = mergePending({ carried, declared, candidateById });
+
+  assert.equal(Object.keys(pending).length, PENDING_MAX_ENTRIES);
+  assert.deepEqual(notAdmitted.map((n) => n.id), ['t3_fresh']);
+  for (let i = 0; i < PENDING_MAX_ENTRIES; i += 1) {
+    assert.ok(pending[`t3_old${i}`], `in-flight entry t3_old${i} survives a full bucket`);
+    assert.equal(pending[`t3_old${i}`].attempts, 2, 'and keeps the looks it already spent');
+  }
+});
+
+test('a re-declared entry is not treated as new when the bucket is full', () => {
+  // The bucket is full and every entry was presented and re-declared. None of
+  // them is new, so nothing may be evicted even though the cap is reached.
+  const carried = {};
+  const declared = {};
+  const candidateById = new Map();
+  for (let i = 0; i < PENDING_MAX_ENTRIES; i += 1) {
+    carried[`t3_p${i}`] = nearMiss(i, { firstSeen: '2026-09-06', attempts: 1 });
+    declared[`t3_p${i}`] = nearMiss(i, { firstSeen: '2026-09-06', attempts: 2 });
+    candidateById.set(`t3_p${i}`, { id: `t3_p${i}`, kind: 'post' });
+  }
+
+  const { pending, notAdmitted } = mergePending({ carried, declared, candidateById });
+
+  assert.equal(notAdmitted.length, 0, 'a re-declaration is a continuation, not an admission');
+  assert.equal(Object.keys(pending).length, PENDING_MAX_ENTRIES);
+  assert.ok(
+    Object.values(pending).every((e) => e.attempts === 2),
+    'every entry keeps the look it just spent'
+  );
 });
 
 // Carrying forward must not become immortality: the entry keeps its original


### PR DESCRIPTION
## Why

Today's scheduled run (#2159) got hit hard by Reddit rate limiting:

- five 61s backoffs (305s spent waiting)
- `/new` page 2 lost, so only 1 of up to 4 pages was crawled
- the megathread source failed outright
- only 2 of 5 pending revisits were fetched

Meanwhile the pending bucket had grown to 14 entries against 6 revisit slots per run, so entries were hitting the 7-day limit without ever being looked at. In the follow-up list that is indistinguishable from "we chased it and the poster never answered".

## Changes

**`CAPS.requestSpacingMs` 8s to 15s.** Three unauthenticated local routines share this IP (`card-news-local`, `reddit-product-changes-local`, this one). A backoff costs 61s, so trading ~7s of spacing to avoid even one wins on wall-clock as well as coverage: ~13 requests at 15s is ~3.3 minutes, inside the 3-5 minute budget the routine already claims, against a run that spent 305s in backoffs alone.

**New `PENDING_MAX_ENTRIES = 8`,** sized a little above `CAPS.revisitPosts` (6) so a full bucket still drains in about a run. Enforced as admission control on brand-new near-misses only:

- Entries already in flight are never evicted. Evicting those would undo the 2026-08-13 `rankPending` starvation fix, wasting every request already spent on them.
- A refused entry is reported with its link and note, so it stays askable by hand. It just gets no automatic revisits.
- The generated extraction prompt now states the cap, so a session writes its strongest near-misses first instead of padding.

## Tests

Three new cases in `check-reddit-datapoints.test.js` covering the cap, the brand-new-only eviction rule, and the case where a full bucket is entirely re-declarations (nothing may be evicted). Full suite passes.