### PR TITLE
Reddit product changes for review — 2026-09-09

### DIFF
--- a/data/reddit-product-changes/2026-05-t3_1w60jys.yaml
+++ b/data/reddit-product-changes/2026-05-t3_1w60jys.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1w60jys
+permalink: https://www.reddit.com/r/CreditCards/comments/1w60jys/time_to_add_another_credit_card/
+posted: "2026-09-03"
+evidence: >-
+  In a card-list request for recommendations, the poster shows their Amex Business Gold opened
+  October 2025 and annotates that line as upgraded to Platinum in May 2026, so the business account
+  was converted to the business Platinum.
+from_card: American Express Business Gold
+to_card: The Business Platinum Card
+change_month: 2026-05
+reason: voluntary

--- a/data/reddit-product-changes/2026-09-t3_1w6poos.yaml
+++ b/data/reddit-product-changes/2026-09-t3_1w6poos.yaml
@@ -1,0 +1,11 @@
+source_id: t3_1w6poos
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1w6poos/deciding_whether_holding_2_amex_plats_is_worth_it/
+posted: "2026-09-04"
+evidence: >-
+  While weighing whether to keep two Amex Platinum cards, the poster lists their current lineup and
+  notes the Amex Green in it came from downgrading their Gold, described as done just recently.
+from_card: American Express Gold
+to_card: American Express Green
+change_month: 2026-09
+reason: voluntary

--- a/data/reddit-product-changes/2026-09-t3_1waozwf.yaml
+++ b/data/reddit-product-changes/2026-09-t3_1waozwf.yaml
@@ -1,0 +1,13 @@
+source_id: t3_1waozwf
+permalink: >-
+  https://www.reddit.com/r/CreditCards/comments/1waozwf/data_point_product_changed_premium_rewards_to/
+posted: "2026-09-08"
+evidence: >-
+  Poster reports their annual fee had just posted and they had no travel plans, so they called the
+  number on the back of the card that morning and asked to product change to a no annual fee card.
+  The rep read out the available options and moved the account to Travel Rewards, with the annual
+  fee to be refunded within 30 days.
+from_card: Bank of America Premium Rewards
+to_card: Bank of America Travel Rewards
+change_month: 2026-09
+reason: voluntary


### PR DESCRIPTION
Product changes extracted from r/CreditCards.

| From | To | Month | Reason | Source |
|---|---|---|---|---|
| American Express Business Gold | The Business Platinum Card | 2026-05 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1w60jys/time_to_add_another_credit_card/) |
| American Express Gold | American Express Green | 2026-09 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1w6poos/deciding_whether_holding_2_amex_plats_is_worth_it/) |
| Bank of America Premium Rewards | Bank of America Travel Rewards | 2026-09 | voluntary | [src](https://www.reddit.com/r/CreditCards/comments/1waozwf/data_point_product_changed_premium_rewards_to/) |

