### PR TITLE
Aeroplan rename and refresh, Navy Federal Flagship Premier, stale our_take fixes

### DIFF
--- a/apps/api/migrations/057_rename_chase_air_canada_aeroplan.sql
+++ b/apps/api/migrations/057_rename_chase_air_canada_aeroplan.sql
@@ -1,0 +1,13 @@
+-- Chase rebrand (September 10, 2026): Aeroplan -> Air Canada Aeroplan.
+--
+-- Chase refreshed and renamed the product on 2026-09-10. The live apply page
+-- (creditcards.chase.com/travel-credit-cards/aircanada/aeroplan) now titles it
+-- "Air Canada Aeroplan(R) Card" and the terms refer to it throughout as the
+-- "Chase Air Canada Aeroplan Card". The refresh also raised the annual fee from
+-- $95 to $195 and added automatic Aeroplan 25K Status, a 15% award discount and
+-- up to $100 a year in Air Canada statement credits.
+--
+-- Must run BEFORE the renamed cards.json reaches the sync: update-cards-github.js
+-- links rows by card_name, so a rename that lands in the CDN first would create a
+-- second row and strand this card's ratings, stats and CardWire history.
+UPDATE cards SET card_name = 'Air Canada Aeroplan' WHERE card_name = 'Aeroplan';

--- a/data/cards/chase-aeroplan.yaml
+++ b/data/cards/chase-aeroplan.yaml
@@ -1,4 +1,6 @@
-name: "Aeroplan"
+name: "Air Canada Aeroplan"
+previous_names:
+  - "Aeroplan"
 bank: "Chase"
 slug: "chase-aeroplan"
 image: "chase-aeroplan.png"
@@ -6,16 +8,28 @@ accepting_applications: true
 annual_fee: 195
 reward_type: "points"
 rewards:
+  # Chase splits Air Canada direct purchases out from the broader travel
+  # category: both earn 3x from the card, but only Air Canada purchases stack
+  # with the extra 2x Air Canada pays Aeroplan 25K members, for up to 5x total.
   - category: airlines
     value: 3
     unit: points_per_dollar
-    note: "Air Canada direct purchases"
+    note: "Air Canada direct purchases, which stack with 2x from Air Canada as a 25K member for up to 5x total"
     merchant_gate: [air-canada]
-  - category: dining
+  - category: travel
     value: 3
     unit: points_per_dollar
+    note: "Travel other than Air Canada direct purchases, which earn 3x under the airlines category"
+  - category: dining
+    value: 2
+    unit: points_per_dollar
+    note: "Purchases posting through December 31, 2026 earn 3x, then 2x"
   - category: groceries
-    value: 3
+    value: 2
+    unit: points_per_dollar
+    note: "Purchases posting through December 31, 2026 earn 3x, then 2x"
+  - category: gas
+    value: 2
     unit: points_per_dollar
   - category: everything_else
     value: 1
@@ -25,7 +39,7 @@ signup_bonus:
   type: "points"
   spend_requirement: 20000
   timeframe_months: 12
-  note: "Earn 75,000 bonus points after you spend $4,000 on purchases in the first 3 months your account is open, plus 40,000 bonus points after a total of $20,000 in purchases within 12 months of account opening, for a possible total of 115,000 points."
+  note: "75,000 points after $4,000 in purchases in the first 3 months, plus 40,000 points after $20,000 in purchases in the first 12 months"
 apr:
   regular:
     min: 19.74
@@ -33,13 +47,30 @@ apr:
 benefits:
   - name: "First Checked Bag Free"
     value: 0
-    description: "Free first checked bag for cardmember and up to 8 companions on Air Canada flights"
+    description: "Free first checked bag for the primary cardmember and up to eight other passengers on the same reservation on Air Canada flights"
     frequency: "ongoing"
     category: "travel"
-  - name: "Aeroplan 25K Elite Status"
+  - name: "Automatic Aeroplan 25K Status"
     value: 0
-    description: "Two years of Aeroplan 25K Elite Status for new cardmembers"
+    description: "Aeroplan 25K Status with no spend requirement for as long as the account is open, including Priority Check-In, Priority Boarding in Zone 2, additional baggage allowance, Star Alliance recognition and eUpgrade credits"
     frequency: "ongoing"
+    category: "travel"
+  - name: "15% Off Air Canada Award Flights"
+    value: 0
+    description: "FLY15OFF reduces the Aeroplan points needed for the base fare of eligible Air Canada, Air Canada Express and Air Canada Rouge flight rewards by at least 15%"
+    frequency: "ongoing"
+    category: "travel"
+  - name: "Air Canada Statement Credits"
+    value: 100
+    description: "Up to $50 in statement credits for eligible Air Canada purchases from January 1 through June 30 and up to $50 from July 1 through December 31, for up to $100 each calendar year"
+    frequency: "annual"
+    category: "travel"
+    merchants:
+      - air-canada
+  - name: "Aeroplan 35K Status for $75,000 Spend"
+    value: 0
+    description: "Spend $75,000 in a calendar year to earn Aeroplan 35K Status for the rest of that year and the following year"
+    frequency: "annual"
     category: "travel"
   - name: "Global Entry / TSA PreCheck / NEXUS Credit"
     value: 120
@@ -50,16 +81,6 @@ benefits:
   - name: "No Foreign Transaction Fees"
     value: 0
     description: "Pay no foreign transaction fees on purchases made outside the United States"
-    frequency: "ongoing"
-    category: "travel"
-  - name: "Monthly Spend Bonus"
-    value: 0
-    description: "Earn 500 bonus points for every $2,000 spent monthly, up to 1,500 bonus points per month"
-    frequency: "monthly"
-    category: "rewards"
-  - name: "Ultimate Rewards Transfer Bonus"
-    value: 0
-    description: "10% bonus when transferring 50,000 or more Ultimate Rewards points to Aeroplan"
     frequency: "ongoing"
     category: "travel"
   - name: "24/7 Concierge"
@@ -75,16 +96,20 @@ apply_link: https://creditcards.chase.com/travel-credit-cards/aircanada/aeroplan
 foreign_transaction_fee: false
 network: "mastercard"
 our_take: >
-  The Aeroplan card is unusually good for a $95 airline card because its bonus
-  categories are not airline-specific: 3x points on dining and on groceries,
-  which most people spend on every week, alongside 3x on Air Canada purchases.
-  New cardmembers get two years of Aeroplan 25K Elite Status, a free first
-  checked bag for the cardmember and up to eight companions on Air Canada, a
-  Global Entry, TSA PreCheck, or NEXUS credit, and no foreign transaction
-  fees. A monthly spend bonus adds 500 points per $2,000 spent, capped at
-  1,500 points a month. Be aware the signup bonus was cut from 75,000 to
-  60,000 points in June, so the current 60,000 after $3,000 in 3 months is
-  below where it recently sat. The card really pays off only if Aeroplan
-  redemptions fit your travel, since everything outside those categories earns
-  a flat 1x.
-
+  Chase refreshed this card on September 10, 2026 and roughly doubled the
+  annual fee to $195, so the value case now rests on Air Canada specifically
+  rather than on broad everyday categories. The headline addition is automatic
+  Aeroplan 25K Status for as long as the account stays open, with no spend
+  requirement, which brings priority check-in, Zone 2 boarding and eUpgrade
+  credits. A standing 15% discount on eligible Air Canada award redemptions
+  and up to $100 a year in Air Canada statement credits, paid as two $50
+  halves, effectively bring the fee back to about $95 if you fly Air Canada at
+  all. Travel earns 3x across the board and Air Canada purchases reach up to
+  5x once the 25K bonus is layered on. The cost of all this is the everyday
+  earning: groceries and dining drop from 3x to 2x for purchases posting after
+  December 31, 2026, the 500 points per $2,000 monthly spend bonus is retired,
+  and the 10% bonus on Ultimate Rewards transfers to Aeroplan ends on that
+  same date. Free first checked bags for the cardmember and up to eight
+  companions, a Global Entry, TSA PreCheck or NEXUS credit and no foreign
+  transaction fees all carry over. This is now a card for people who actually
+  fly Air Canada, not a general-purpose 3x earner.

--- a/data/cards/navy-federal-flagship-premier.yaml
+++ b/data/cards/navy-federal-flagship-premier.yaml
@@ -1,0 +1,92 @@
+name: "Navy Federal Flagship Premier Visa Signature"
+bank: "Navy Federal"
+slug: "navy-federal-flagship-premier"
+accepting_applications: true
+category: "travel"
+release_date: "2026-09-10"
+annual_fee: 95
+reward_type: "points"
+tags:
+  - travel
+  - rewards
+  - premium
+rewards:
+  - category: travel
+    value: 4
+    unit: points_per_dollar
+  - category: dining
+    value: 3
+    unit: points_per_dollar
+  - category: everything_else
+    value: 1
+    unit: points_per_dollar
+signup_bonus:
+  value: 50000
+  type: "points"
+  spend_requirement: 4000
+  timeframe_months: 3
+  note: "Worth $500; for accounts opened between 9/10/2026 and 1/3/2027"
+apr:
+  regular:
+    min: 15.74
+    max: 18.00
+benefits:
+  - name: "Annual Airline Credit"
+    value: 100
+    description: "$100 statement credit each year after spending $100 or more on eligible airline purchases with the card"
+    frequency: "annual"
+    category: "travel"
+    enrollment_required: false
+  - name: "Global Entry / TSA PreCheck Credit"
+    value: 120
+    description: "Up to $120 in statement credits for Global Entry or TSA PreCheck application fees, once every 4 years"
+    frequency: "every_4_years"
+    category: "travel"
+    enrollment_required: false
+  - name: "GigSky Global Data Plan"
+    value: 20
+    description: "Complimentary 3GB GigSky global mobile data plan, valid for up to 15 days after activation, when the card is the default payment method in the GigSky app"
+    category: "travel"
+    enrollment_required: true
+  - name: "Collision Damage Waiver"
+    value: 0
+    description: "Rental car collision damage waiver coverage on rentals of 15 days or less"
+    category: "insurance"
+    enrollment_required: false
+  - name: "Travel Accident Insurance"
+    value: 0
+    description: "Worldwide automatic travel accident insurance when travel is purchased with the card"
+    category: "insurance"
+    enrollment_required: false
+  - name: "Travel and Emergency Assistance"
+    value: 0
+    description: "24/7 travel and emergency assistance including medical referral, lost luggage locator, and prescription assistance"
+    category: "travel"
+    enrollment_required: false
+  - name: "No Balance Transfer Fees"
+    value: 0
+    description: "Navy Federal does not charge balance transfer fees on this card"
+    category: "other"
+    enrollment_required: false
+  - name: "No Cash Advance Fees"
+    value: 0
+    description: "Navy Federal does not charge cash advance fees, though ATM fees may apply outside Navy Federal locations"
+    category: "other"
+    enrollment_required: false
+foreign_transaction_fee: false
+network: "visa"
+apply_link: https://www.navyfederal.org/loans-cards/credit-cards/flagship-premier-visa-signature.html
+our_take: >
+  The Flagship Premier is Navy Federal's first metal card and its most
+  travel-focused one, sitting above the older Flagship Rewards at the same $95
+  annual fee both cards now carry. It earns 4x on travel and 3x on dining, and
+  the $100 annual airline credit covers the fee outright if you put at least
+  $100 of airline spend on the card in a year. A Global Entry or TSA PreCheck
+  credit of up to $120 every 4 years, rental car collision coverage, travel
+  accident insurance and no foreign transaction fee make it a genuinely
+  capable travel card for the price. The tradeoff is the floor: everything
+  outside travel and dining earns 1x, down from the flat 2x that made Flagship
+  Rewards worth using on ordinary spend, so this is the better card only if
+  travel and dining dominate your budget. There is no lounge access and no
+  hotel or airline status, and membership is limited to the military
+  community, so it competes on value rather than on premium perks.

--- a/data/cards/navy-federal-flagship-rewards.yaml
+++ b/data/cards/navy-federal-flagship-rewards.yaml
@@ -8,19 +8,23 @@ annual_fee: 95
 foreign_transaction_fee: false
 network: "visa"
 our_take: >
-  The Flagship pairs a $49 annual fee with a $139 annual statement credit
-  covering an Amazon Prime membership paid with the card, so the fee is more
-  than covered if you were buying Prime anyway. Earn rates are solid and
-  broadly defined: 3 points per dollar on travel that includes airlines,
-  hotels, car rentals, ride-sharing, parking, tolls, museums, amusement parks,
-  and golf courses, plus 2x on everything else, which is a strong floor for a
-  card at this price. The welcome offer is 35,000 points worth $350 after
-  $3,500 in purchases within 3 months, and there is a Global Entry or TSA
-  PreCheck credit of up to $120 once every 4 years. No foreign transaction
-  fee, travel accident insurance, and 24/7 emergency assistance round out a
-  genuinely travel-ready package. The limitation is scale rather than quality:
-  there is no lounge access and no hotel or airline status, so this is a value
-  travel card, not a competitor to premium $500-plus products.
+  The Flagship Rewards pairs a $95 annual fee, up from $49 as of November 2,
+  2026, with a $139 annual statement credit covering an Amazon Prime
+  membership paid with the card, so the fee is still more than covered if you
+  were buying Prime anyway. Earn rates are solid and broadly defined: 3 points
+  per dollar on travel that includes airlines, hotels, car rentals,
+  ride-sharing, parking, tolls, museums, amusement parks, and golf courses,
+  plus 2x on everything else, which remains a strong floor at this price. The
+  welcome offer is 50,000 points worth $500 after $4,000 in purchases within 3
+  months, and there is a Global Entry or TSA PreCheck credit of up to $120
+  once every 4 years. No foreign transaction fee, travel accident insurance,
+  and 24/7 emergency assistance round out a genuinely travel-ready package.
+  Navy Federal now also offers the Flagship Premier at the same $95 fee, which
+  swaps the Prime credit for a $100 airline credit and pays 4x on travel and
+  3x on dining but only 1x on everything else, so this card is still the
+  better pick if your spending is spread out. The limitation is scale rather
+  than quality: there is no lounge access and no hotel or airline status, so
+  this is a value travel card, not a competitor to premium $500-plus products.
 reward_type: "points"
 tags:
   - travel
@@ -39,7 +43,7 @@ signup_bonus:
   type: "points"
   spend_requirement: 4000
   timeframe_months: 3
-  note: "Worth $350; offer valid for applications through 1/3/2027"
+  note: "Worth $500; offer valid for applications through 1/3/2027"
 apr:
   regular:
     min: 14.74


### PR DESCRIPTION
Manual follow-up to #2168. That PR's extractor catches numeric fields only, so it correctly picked up Aeroplan's $195 fee and 115k offer but missed the rename, the rewards and benefit changes, and the prose contradicting them.

**Do not merge until migration 057 has been applied.** `update-cards-github.js` links DB rows by `card_name`, so if the renamed `cards.json` reaches the sync first it creates a second row and strands this card's ratings, stats and CardWire history. Sequence: deploy + invoke `057_rename_chase_air_canada_aeroplan.sql`, verify the row, then merge.

### Aeroplan (Chase refreshed and renamed it 2026-09-10)

| Field | Before | After | Source |
|---|---|---|---|
| name | Aeroplan | Air Canada Aeroplan (+ `previous_names`) | [apply page](https://creditcards.chase.com/travel-credit-cards/aircanada/aeroplan), [Chase press release](https://media.chase.com/news/the-chase-air-canada-aeroplan-credit-card-refresh) |
| travel | (none) | 3x as its own category | apply page |
| airlines (Air Canada direct) | 3x | 3x, stacking to 5x total with 2x from Air Canada as a 25K member | apply page |
| dining | 3x | 2x, 3x through 2026-12-31 | apply page |
| groceries | 3x | 2x, 3x through 2026-12-31 | apply page |
| gas | (none) | 2x | apply page |
| Aeroplan 25K Status | Two years, new cardmembers | Automatic, no spend requirement, for the life of the account | apply page |
| 15% award discount (FLY15OFF) | — | added | apply page |
| Air Canada statement credits | — | up to $100/yr as two $50 halves | apply page |
| Aeroplan 35K Status | — | added at $75,000 calendar-year spend | apply page |
| Monthly spend bonus | 500 per $2,000 | removed (retired) | [Upgraded Points](https://upgradedpoints.com/news/refreshed-chase-aeroplan-card-2026/) |
| 10% UR transfer bonus | present | removed (ends 2026-12-31) | Upgraded Points |
| Global Entry / TSA / NEXUS | present | kept | Upgraded Points |

The new marketing page does not list the Global Entry credit, so I verified it separately rather than treating the omission as removal. The monthly spend bonus and UR transfer bonus both run for existing cardmembers through 2026-12-31 but are not part of the product going forward, so they come out of the card data; the [news item](https://creditodds.com/news/chase-aeroplan-card-refresh-live) covers the wind-down.

### Navy Federal

- **Adds Flagship Premier Visa Signature**, launched 2026-09-10. $95, 4x travel, 3x dining, 1x else, $100 annual airline credit, up to $120 Global Entry/TSA PreCheck every 4 years, GigSky data plan, no FTF/BT/cash advance fees, 15.74%-18.00% APR, 50,000 points after $4,000 in 90 days. Verified against [Navy Federal's product page](https://www.navyfederal.org/loans-cards/credit-cards/flagship-premier-visa-signature.html).
- **No image.** The only art Navy Federal publishes is angled with a NEW ribbon baked in, which does not match the flat front-only art every other card uses. Two cards already ship without one. Worth revisiting if flat art appears.
- **Flagship Rewards `our_take` was stale and publicly wrong**: it described the $49 fee and the 35,000 point offer directly beneath the $95 fee and 50,000 point SUB that #2164 and #2168 had already corrected. Also rewritten to mention the Premier upgrade path. SUB note said "Worth $350"; 50,000 points is $500 per Navy Federal.

Validated with `npm run build:cards` (227 cards). `cards.json` intentionally not committed.