### PR TITLE
news: show card art beside archive headlines

### DIFF
--- a/apps/web-next/src/app/landing.css
+++ b/apps/web-next/src/app/landing.css
@@ -2573,6 +2573,40 @@
 .landing-v2 .news-item:hover .ni-title {
   color: var(--accent);
 }
+/* Title on the left, card art on the right. min-width:0 lets the heading wrap
+   instead of forcing the row wider than the column. */
+.landing-v2 .news-item .ni-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+.landing-v2 .news-item .ni-head .ni-title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.landing-v2 .news-item .ni-cards {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  padding-top: 2px;
+}
+.landing-v2 .news-item .ni-card {
+  position: relative;
+  display: block;
+  width: 60px;
+  aspect-ratio: 1000 / 634;
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  background: var(--paper-2);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.12);
+}
+/* Stories tagged with several cards fan out to the right, first card on top.
+   The inline z-index descends per card so the overlap reads front-to-back. */
+.landing-v2 .news-item .ni-card + .ni-card {
+  margin-left: -40px;
+}
 .landing-v2 .news-item .ni-excerpt {
   font-size: 13px;
   color: var(--muted);
@@ -2768,6 +2802,15 @@
   .landing-v2 .news-archive-list .news-item:nth-child(2) {
     border-top: 1px solid var(--line);
     padding-top: 18px;
+  }
+  .landing-v2 .news-item .ni-head {
+    gap: 10px;
+  }
+  .landing-v2 .news-item .ni-card {
+    width: 48px;
+  }
+  .landing-v2 .news-item .ni-card + .ni-card {
+    margin-left: -32px;
   }
   /* The search input and the issuer select each want the full width here, so
      wrap them onto separate lines instead of letting the select crush the

--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -457,18 +457,46 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
           ) : (
             <>
               <div className="news-archive-list">
-                {shown.map((item) => (
-                  <Link key={item.id} href={`/news/${item.id}`} className="news-item">
-                    <div className="ni-meta">
-                      <span className="news-tag">{TAG_DISPLAY[primaryTag(item)]}</span>
-                      <span>{formatDate(item.date)}</span>
-                      {item.bank ? <> · {item.bank}</> : null}
-                      {viewsOf(item) > 100 && <> · {viewsOf(item).toLocaleString('en-US')} views</>}
-                    </div>
-                    <h3 className="ni-title">{item.title}</h3>
-                    <p className="ni-excerpt">{plainSummary(item.summary)}</p>
-                  </Link>
-                ))}
+                {shown.map((item) => {
+                  // Cards without art would render the generic placeholder, which
+                  // is noise next to a headline that already names the card.
+                  const cards = getNewsCards(item).filter((c) => c.image);
+                  return (
+                    <Link key={item.id} href={`/news/${item.id}`} className="news-item">
+                      <div className="ni-meta">
+                        <span className="news-tag">{TAG_DISPLAY[primaryTag(item)]}</span>
+                        <span>{formatDate(item.date)}</span>
+                        {item.bank ? <> · {item.bank}</> : null}
+                        {viewsOf(item) > 100 && <> · {viewsOf(item).toLocaleString('en-US')} views</>}
+                      </div>
+                      <div className="ni-head">
+                        <h3 className="ni-title">{item.title}</h3>
+                        {cards.length > 0 && (
+                          // Decorative: the headline and excerpt already name the
+                          // cards, so announcing each image repeats the row.
+                          <div className="ni-cards" aria-hidden="true">
+                            {cards.slice(0, 3).map((c, i) => (
+                              <span
+                                key={c.slug}
+                                className="ni-card"
+                                style={{ zIndex: cards.length - i }}
+                              >
+                                <CardImage
+                                  cardImageLink={c.image ?? undefined}
+                                  alt=""
+                                  fill
+                                  sizes="60px"
+                                  style={{ objectFit: 'cover' }}
+                                />
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <p className="ni-excerpt">{plainSummary(item.summary)}</p>
+                    </Link>
+                  );
+                })}
               </div>
 
               {shown.length < filtered.length && (


### PR DESCRIPTION
The archive list under "Every story, newest first" was text only, so scanning it gave no visual cue which card a story is about, even though `getNewsCards()` already resolves the art for the featured and secondary cards higher up the same page.

Each row now renders the card image to the right of its headline. Stories tagged with several cards fan the art out as an overlapping stack with the first card on top.

**Details**
- Capped at 3 images. 35 of the current 142 items carry more than one card, and the Peacock story carries 5, which would otherwise crowd the headline.
- Cards with no art are filtered out rather than falling back to `generic-card.svg`, which reads as noise beside a headline that already names the card. This matters now that Navy Federal Flagship Premier ships imageless (#2169).
- The stack is `aria-hidden` and the images carry empty alt, since the headline and excerpt already convey the same information. Announcing each image would repeat the row.
- Thumbnails are 60px wide at `aspect-ratio: 1000 / 634` to match the source art, dropping to 48px under 760px where the list collapses to one column.
- `.ni-title` gets `min-width: 0` inside the new flex row so long headlines wrap rather than widening the column.

**Verification:** `tsc --noEmit` clean, and `eslint` clean on both changed files. The repo has 19 pre-existing lint errors on `main` unrelated to this change (identical count with these edits stashed). I could not render the page: dev servers cannot be started from this unattended session, so the visual result is worth a look before merge, particularly the 4 and 5 card rows.