### PR TITLE
fix: give news card thumbnails a non-empty alt

### DIFF
--- a/apps/web-next/src/app/news/NewsV2Client.tsx
+++ b/apps/web-next/src/app/news/NewsV2Client.tsx
@@ -472,8 +472,12 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
                       <div className="ni-head">
                         <h3 className="ni-title">{item.title}</h3>
                         {cards.length > 0 && (
-                          // Decorative: the headline and excerpt already name the
-                          // cards, so announcing each image repeats the row.
+                          // aria-hidden because the headline and excerpt already
+                          // name the cards; announcing each image repeats the row.
+                          // The alt text still has to be non-empty: check-seo.mjs
+                          // fails the build on an empty alt attribute, since Bing
+                          // reads that as a missing one, and aria-hidden does not
+                          // exempt it.
                           <div className="ni-cards" aria-hidden="true">
                             {cards.slice(0, 3).map((c, i) => (
                               <span
@@ -483,7 +487,7 @@ export default function NewsV2Client({ items, viewCounts }: NewsV2ClientProps) {
                               >
                                 <CardImage
                                   cardImageLink={c.image ?? undefined}
-                                  alt=""
+                                  alt={c.name}
                                   fill
                                   sizes="60px"
                                   style={{ objectFit: 'cover' }}


### PR DESCRIPTION
**Fixes the broken Amplify build on `main`** (job 1735). My fault: #2170 shipped the new news thumbnails with an empty `alt`, which `scripts/check-seo.mjs` rejects as a prebuild step because Bing treats an empty alt as a missing one. The `aria-hidden` on the wrapper does not exempt it, since the checker greps the file rather than parsing JSX.

The images now use the card name for alt. They stay `aria-hidden` on the container, so screen readers still do not double-announce cards the headline already names.

The explanatory comment had to avoid the literal empty-alt string as well, for the same grep reason.

**Verification, done properly this time:** `check-seo.mjs` passes, `tsc --noEmit` clean, and a full `next build` completes. I previously only type-checked, which is what let this through. The last good deploy is still serving, so the site is current as of #2168; #2169 and #2170 land once this goes in.