### PR TITLE
sentry: drop WebKit's default-message AbortError from Firebase IDB teardown

### DIFF
--- a/apps/web-next/src/lib/benignClientError.test.ts
+++ b/apps/web-next/src/lib/benignClientError.test.ts
@@ -30,6 +30,22 @@ describe("isBenignClientError", () => {
     ).toBe(true);
   });
 
+  it("drops WebKit's default-message AbortError from IDB teardown", () => {
+    // Safari populates tx.error with its platform default AbortError text
+    // where Chrome leaves it null (bare "AbortError" above).
+    expect(
+      isBenignClientError(domException("The operation was aborted.")),
+    ).toBe(true);
+  });
+
+  it("keeps 'The operation was aborted.' when it is not an AbortError", () => {
+    expect(
+      isBenignClientError(
+        domException("The operation was aborted.", "UnknownError", 0),
+      ),
+    ).toBe(false);
+  });
+
   it("walks the cause chain when Firebase wraps the DOMException", () => {
     const wrapped = {
       name: "Error",

--- a/apps/web-next/src/lib/benignClientError.ts
+++ b/apps/web-next/src/lib/benignClientError.ts
@@ -97,10 +97,25 @@
 //    hypothetical real image-load failure pointing at an https URL stays
 //    reportable.
 //
+// The same Firebase IndexedDB teardown has a WebKit-specific spelling:
+// "AbortError: The operation was aborted." (CREDITODDS-JAVASCRIPT-NEXTJS,
+// issue 7728583818, Mobile Safari on /best-card-for/:slug after a reload).
+// Firebase's `idb` wrapper rejects `tx.done` with `tx.error || new
+// DOMException('AbortError', 'AbortError')` (idb/build/wrap-idb-value.js).
+// Chrome leaves `tx.error` null when the connection closes mid-transaction,
+// producing the bare "AbortError" message matched below; WebKit instead
+// populates it with a DOMException carrying its platform default AbortError
+// text, "The operation was aborted." Nothing on this site ever aborts a fetch
+// (fetchWithRetry only attaches never-aborting signals), so an AbortError with
+// WebKit's generic default message has no other origin worth reporting. It is
+// kept behind the AbortError name/code gate, and Chrome's descriptive fetch
+// abort ("The user aborted a request.") stays reportable.
+//
 // Finally, hasOnlyForeignFrames (below) drops exceptions by stack shape rather
 // than message: every frame lacks a resolvable script URL. See its comment.
 const BENIGN_CLIENT_SIGNATURES = [
   'The transaction was aborted',
+  'The operation was aborted.',
   'database connection is closing',
   'idb-get',
   'idb-set',


### PR DESCRIPTION
## Summary

Sentry issue **7728583818** (`AbortError: The operation was aborted.`, unhandled rejection, Mobile Safari 26.6.1 / iOS 18.7 on `/best-card-for/madewell`) is the WebKit spelling of the Firebase IndexedDB teardown noise `benignClientError.ts` already drops for Chrome.

**Mechanism.** Firebase (`@firebase/app` heartbeats, `@firebase/installations`) goes through the `idb` wrapper, whose `tx.done` rejects with `tx.error || new DOMException('AbortError', 'AbortError')` (`idb/build/wrap-idb-value.js:77`). When Safari tears the IndexedDB connection down mid-transaction (the breadcrumbs show a same-URL reload, then Firebase / Analytics init, then the rejection):

- Chrome leaves `tx.error` null → bare `"AbortError"` message → already filtered.
- WebKit populates `tx.error` with a DOMException carrying its platform-default AbortError text, `"The operation was aborted."` → this issue.

Nothing we ship aborts a fetch (`fetchWithRetry` only attaches never-aborting signals), so an AbortError with WebKit's generic default text has no other reportable origin.

## Change

- Add `'The operation was aborted.'` to the abort-gated `BENIGN_CLIENT_SIGNATURES` (still requires `name === 'AbortError'` or `code === 20`).
- Tests: drops the WebKit DOMException shape; keeps the same text when it is not an AbortError. The existing test that keeps Chrome's descriptive fetch abort (`"The user aborted a request."`) is unchanged.

Sentry auth token in `.env.local` is commented out, so the event's stack frames could not be pulled via the API; the diagnosis is from the idb source plus the breadcrumb ordering.

## Test plan

- [x] `npx vitest run src/lib/benignClientError.test.ts` → 38 passed